### PR TITLE
routines to sync EUVM and integrated reports data from MAVEN SDC

### DIFF
--- a/PyUVS/search.py
+++ b/PyUVS/search.py
@@ -376,3 +376,25 @@ def dropxml(files):
     """
 
     return [f for f in files if f[-3:] != 'xml']
+
+
+def get_euvm_l2b_filename():
+    """
+    Returns the most recent EUVM L2B file available
+
+    Parameters
+    ----------
+    none
+
+    Returns
+    -------
+    euvm_l2b_fname : str
+       Filename of EUVM L2B save file.
+    """
+    from PyUVS.download import get_euvm_l2b_dir
+
+    euvm_l2b_dir = get_euvm_l2b_dir()
+
+    euvm_l2b_fname = sorted(glob.glob(euvm_l2b_dir+"*l2b*.sav"))[-1]
+
+    return euvm_l2b_fname

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setuptools.setup(
         'paramiko>=2.6.0',
         'pytz>=2018.9',
         'spiceypy>=2.2.0',
-        'pexpect>=4.8.0'
+        'pexpect>=4.8.0',
+        'twill>=2.0.1'
     ]
 )


### PR DESCRIPTION
These routines sync some ancillary data I use in making H corona quicklooks from the MAVEN SDC. Should be portable to anyone's machine, though I doubt anyone else will use these in exactly the same way. May be useful as a building block for other sync routines.