### PR TITLE
Bug fixes related to dark subtraction, co addition, and orbit numbers:

### DIFF
--- a/maven_iuvs/graphics/echelle_graphics.py
+++ b/maven_iuvs/graphics/echelle_graphics.py
@@ -329,11 +329,11 @@ def make_one_quicklook(index_data_pair, light_path, dark_path, no_geo=None, show
 
     # PROCESS THE DATA ---------------------------------------------------------------------------------
     try: 
-        coadded_lights, bad_inds, n_frames = coadd_lights(light_fits, dark_fits)
+        coadded_lights, n_frames, bad_inds = coadd_lights(light_fits, dark_fits)
     except Exception as e:
         return e
 
-    nan_light_inds, bad_light_inds, bad_dark_inds = bad_inds  # unpack indices of problematic frames
+    nan_light_inds, bad_light_inds, light_frames_with_nan_dark, nan_dark_inds = bad_inds  # unpack indices of problematic frames
 
     # Retrieve the dark frames here also for plotting purposes 
     darks = get_dark_frames(dark_fits)
@@ -513,15 +513,9 @@ def make_one_quicklook(index_data_pair, light_path, dark_path, no_geo=None, show
     DarkAxes[2].set_title("Average dark", fontsize=fontsizes[fs]["title"])
 
     # If dark had a nan, show it but print a message.
-    if np.isnan(first_dark).any():
-        dark_msg_ax = 0
-    elif np.isnan(second_dark).any():
-        dark_msg_ax = 1
-    else:
-        dark_msg_ax = None
-
-    if dark_msg_ax is not None:
-        DarkAxes[dark_msg_ax].text(0, -0.05, "Dark frame with NaNs not included in dark subtraction.", fontsize=14, transform=DarkAxes[dark_msg_ax].transAxes)
+    if len(nan_dark_inds) != 0:
+        for i in nan_dark_inds:
+            DarkAxes[i].text(0, -0.05, "Dark frame with NaNs not included in dark subtraction.", fontsize=14, transform=DarkAxes[i].transAxes)
     
     # Plot the geometry frames ---------------------------------------------------------------------------------
     if index_data_pair[0]['name'] in no_geo:
@@ -543,7 +537,7 @@ def make_one_quicklook(index_data_pair, light_path, dark_path, no_geo=None, show
             ThumbAxes[i].text(0.1, 1.1, "Missing data", color=color_dict['darkgrey'], va="top", fontsize=14, transform=ThumbAxes[i].transAxes)
         elif i in bad_light_inds:
             ThumbAxes[i].text(0.1, 1.1, "Saturated/broken", color=color_dict['darkgrey'], va="top", fontsize=14, transform=ThumbAxes[i].transAxes)
-        elif i in bad_dark_inds:
+        elif i in light_frames_with_nan_dark:
             ThumbAxes[i].text(0.1, 1.1, "Bad dark frame", color=color_dict['darkgrey'], va="top", fontsize=14, transform=ThumbAxes[i].transAxes)
 
         this_frame = light_fits['Primary'].data[i]

--- a/maven_iuvs/miscellaneous.py
+++ b/maven_iuvs/miscellaneous.py
@@ -3,6 +3,15 @@ import datetime
 import re 
 
 
+# Common regular expressions for parsing filenames
+orbit_set_RE = r"(?<=/orbit)[0-9]{5}(?=/)"
+orbno_RE = r"(?<=-orbit)[0-9]{5}(?=-)"
+datetime_RE = r"(?<=-ech_)[0-9]{8}[tT][0-9]{6}"
+fn_RE = r"(?<=00/).+"
+folder_RE = r".+(?=mvn)"
+uniqueID_RE = r"[a-z]+-orbit[0-9]{5}-[a-z]+_[0-9]{8}[tT]{1}[0-9]{6}"
+
+
 def clear_line(n=100):
     """
     Clears a previously-printed line in the terminal output.
@@ -122,21 +131,28 @@ def orbit_folder(orbit):
     return f"orbit{orbit_set:05}"
 
 
-def iuvs_orbno_from_fname(fname):
+def iuvs_orbno_from_fname(fname, search_full_path=False):
     """
     Collects the orbit number from the filename.
     Parameters
     ----------
     fname : string
             IUVS observation filename
+    search_full_path : boolean
+                       if True, this function will use regular expressions to search the full file path.
+                       Avoids problem where searching the full path using split() returns only the orbit set 
+                       (i.e. 16900 instead of 16910)
 
     Returns
     -------
     orb_string : int
                  orbit number
     """
-    orb_string = str(fname).split('orbit')[1][:5]
-    return int(orb_string)
+    if search_full_path:
+        return int(re.search(orbno_RE, fname).group(0))
+    else:
+        orb_string = str(fname).split('orbit')[1][:5]
+        return int(orb_string)
 
 
 def iuvs_segment_from_fname(fname):

--- a/maven_iuvs/miscellaneous.py
+++ b/maven_iuvs/miscellaneous.py
@@ -1,6 +1,7 @@
 import numpy as np
 import datetime
 import re 
+import os
 
 
 # Common regular expressions for parsing filenames
@@ -131,7 +132,7 @@ def orbit_folder(orbit):
     return f"orbit{orbit_set:05}"
 
 
-def iuvs_orbno_from_fname(fname, search_full_path=False):
+def iuvs_orbno_from_fname(fname):
     """
     Collects the orbit number from the filename.
     Parameters
@@ -148,11 +149,8 @@ def iuvs_orbno_from_fname(fname, search_full_path=False):
     orb_string : int
                  orbit number
     """
-    if search_full_path:
-        return int(re.search(orbno_RE, fname).group(0))
-    else:
-        orb_string = str(fname).split('orbit')[1][:5]
-        return int(orb_string)
+    orb_string = os.path.basename(fname).split('orbit')[1][:5]
+    return int(orb_string)
 
 
 def iuvs_segment_from_fname(fname):


### PR DESCRIPTION
- Add a mode to allow searching for the orbit number in the full file path. This requires regular expressions.
- Clarify dark subtraction code so that it's obvious if the 0th frame is good or not (previously, the 0th frame was excluded from i_all and therefore also i_good, even if it was a valid frame with a valid dark).
- Explicitly return the number of good frames for use elsewhere, e.g. in coaddition.
- Explicitly return "light_frames_with_nan_dark", whereas previously these were included in "nan_dark_inds" which is not clear.
- Allow coadd_lights to not return the list of indices for bad frames if desired.
- add ['name'] index to weekly_report_idx[n] in weekly report code (where n is some index of the file metadata index to explicitly pass iuvs_orbno_from_fname just the filename, rather than the entire index entry (which is then transformed to a string).

## Pull Request Checklist
 - [x] Code Follows PEP8 guidelines (explain any exceptions)
 - [x] New routines don't duplicate existing functionality (no new routines)
 - [x] Original authors of modified routines have been added as reviewers
 
