### PR TITLE
L1a to l1c pipeline

### DIFF
--- a/maven_iuvs/binning.py
+++ b/maven_iuvs/binning.py
@@ -23,18 +23,17 @@ def get_bin_edges(light_fits):
     # Grab the wavelengths 
     wavelengths = get_wavelengths(light_fits)
 
-    # First calculate the differences between all points x
+    # First calculate the differences between wavelengths
     dlambda = np.diff(wavelengths)
     
-    # There will be one more bin edge than x points
+    # There will be one more bin edge than wavelengths
     edges = np.zeros(len(wavelengths) + 1)
 
     # Handle the left edge
     edges[0] = wavelengths[0] - (dlambda[0] / 2) 
 
-    # inner elements
-    for i in range(1, len(edges)-1):
-        edges[i] = wavelengths[i] - dlambda[i-1] / 2
+    # inner elements - end element excluded
+    edges[1:-1] = wavelengths[1:] - (dlambda / 2)
 
     # And the right edge
     edges[-1] = wavelengths[-1] + dlambda[-1] / 2

--- a/maven_iuvs/binning.py
+++ b/maven_iuvs/binning.py
@@ -1,4 +1,5 @@
 import numpy as np
+from maven_iuvs.instrument import get_wavelengths 
 
 def get_bin_edges(light_fits):
     """

--- a/maven_iuvs/binning.py
+++ b/maven_iuvs/binning.py
@@ -1,5 +1,4 @@
 import numpy as np
-from maven_iuvs.instrument import get_wavelengths
 
 def get_bin_edges(light_fits):
     """

--- a/maven_iuvs/binning.py
+++ b/maven_iuvs/binning.py
@@ -1,4 +1,46 @@
 import numpy as np
+from maven_iuvs.instrument import get_wavelengths
+
+def get_bin_edges(light_fits):
+    """
+    Wavelengths as defined in the fits files are defined for the bin centers.
+    This function will calculate where the bin edges should be, since the 
+    recorded bin edges in the files are all for the standard resolution mode, 
+    and not able to be applied to echelle.
+    TODO: The method used here is probably "good enough" but could be improved.
+
+    Parameters:
+    -----------
+    light_fits : astropy.io.fits instance
+                 File with light observation
+    Returns:
+    -----------
+    edges : array
+            Defines the edges of the bins for the wavelengths, so we can calculate the flux
+            to assign to the bins.
+    """    
+
+    # Grab the wavelengths 
+    wavelengths = get_wavelengths(light_fits)
+
+    # First calculate the differences between all points x
+    dlambda = np.diff(wavelengths)
+    
+    # There will be one more bin edge than x points
+    edges = np.zeros(len(wavelengths) + 1)
+
+    # Handle the left edge
+    edges[0] = wavelengths[0] - (dlambda[0] / 2) 
+
+    # inner elements
+    for i in range(1, len(edges)-1):
+        edges[i] = wavelengths[i] - dlambda[i-1] / 2
+
+    # And the right edge
+    edges[-1] = wavelengths[-1] + dlambda[-1] / 2
+    
+    return edges
+
 
 def get_binning_scheme(hdul):
     """

--- a/maven_iuvs/constants.py
+++ b/maven_iuvs/constants.py
@@ -1,3 +1,4 @@
 """Physical constants used in multiple locations."""
 
 R_Mars_km = 3.3895e3  # [km]
+D_offset = 0.034 # [nm], Δλ between H Ly α and D Ly α

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -1819,15 +1819,15 @@ def line_fit_initial_guess(wavelengths, spectrum, H_a=95, H_b=135, D_a=80, D_b=1
     DN_H_guess = sp.integrate.simpson(spectrum[H_a:H_b], x=wavelengths[H_a:H_b]) # Mike said 400 is a good approx..
     DN_D_guess = sp.integrate.simpson(spectrum[D_a:D_b], x=wavelengths[D_a:D_b])
 
-    # central wavelength initial guess - go with the canonical values
+    # central wavelength initial guess - go with the canonical value. There is no need to return a guess for D
+    # because it will be calculated as a constant offset from the H central line, per advice from Mike Stevens.
     lambda_H_lya_guess = 121.567
-    lambda_D_lya_guess = 121.534
 
     # Background initial guess: assume a form y = mx + b. If m = 0, assume a constant offset.
     bg_m_guess = 0
     bg_b_guess = np.median(spectrum)
 
-    return [DN_H_guess, DN_D_guess, lambda_H_lya_guess, lambda_D_lya_guess, bg_m_guess, bg_b_guess]
+    return [DN_H_guess, DN_D_guess, lambda_H_lya_guess, bg_m_guess, bg_b_guess]
 
 # Cosmic ray and hot pixel removal -------------------------------------------
 

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -991,7 +991,7 @@ def get_ech_slit_indices(light_fits):
 # L1c processing ===========================================================
 
 def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibration="new", solv="Powell", fitpackage="scipy", approach="dynamic", 
-                       livepts=500, clean_data=True, clean_method="new", run_writeout=True, check_background=False, IDL_fit_unc=None):
+                       livepts=500, clean_data=True, clean_method="new", run_writeout=True, check_background=False, plot_subtract_bg=True, plot_bg_separately=False, 
     """
     Converts a single l1a echelle observation to l1c. At present, two .csv files containing some 
     quantities that need to be written out to the .fits file are generated and saved, and IDL is 
@@ -1031,6 +1031,8 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
     check_background : boolean
                        whether to make plots showing whether empty regions of the detector
                        minus the background fit there are comparable to zero.
+    plot_subtract_bg : boolean
+                       if True, subtracts background from model and data before plotting them.
 
     Returns
     ----------
@@ -1248,13 +1250,15 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
         fit_params_for_printing['uncert_D'] = D_kR_1sig
 
         # Plot in kR/nm
-        # echgr.plot_line_fit(wavelengths, spec_kR_pernm, I_fit_kR_pernm, fit_params_for_printing, data_unc=data_unc_kR_pernm, t=titletext,
-        #                     plot_bg=bg_array_kR_pernm)
+        echgr.plot_line_fit(wavelengths, spec_kR_pernm, I_fit_kR_pernm, fit_params_for_printing, data_unc=data_unc_kR_pernm, t=titletext,
+                            plot_bg=bg_array_kR_pernm, plot_subtract_bg=plot_subtract_bg, plot_bg_separately=plot_bg_separately)
         
         # Plot a comparison of the two methods ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         echgr.plot_line_fit_comparison(wavelengths, spec_kR_pernm, spec_kR, I_fit_kR_pernm, I_fit_kR_BUbg, fit_params_for_printing, 
-                                 fit_params_for_printing_BUbg, bg_array_kR, bg_array_kR_pernm,
-                                 unit=["kR/nm", "kR"], data_unc_new=data_unc_kR_pernm, data_unc_BU=data_unc_kR, suptitle=titletext)
+                                 fit_params_for_printing_BUbg, bg_array_kR, bg_array_kR_pernm, 
+                                 titles=["Linear background", "Background ~Mayyasi+2023"], 
+                                 plot_subtract_bg=plot_subtract_bg, unit=["kR/nm", "kR"], data_unc_new=data_unc_kR_pernm, 
+                                 data_unc_BU=data_unc_kR, suptitle=titletext)
         
         # Background comparison
         # ============================================================================================

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -1199,12 +1199,14 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
         fit_params_for_printing['uncert_D'] = D_kR_sigma
 
         # Plot in kR/sec/nm
-        plot_line_fit(wavelengths, spec_kR_pernm, I_fit_kR_pernm, fit_params_for_printing, data_unc=unc_kr_per_nm, t=titletext, unit=unittext_kR, 
-                      H_a=H_i[0], H_b=H_i[1], D_a=D_i[0], D_b=D_i[1] )
+        # plot_line_fit(wavelengths, spec_kR_pernm, I_fit_kR_pernm, fit_params_for_printing, data_unc=unc_kr_per_nm, t=titletext, unit=unittext_kR, 
+        #               H_a=H_i[0], H_b=H_i[1], D_a=D_i[0], D_b=D_i[1] )
         
         # Also plot with the BU background ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        plot_line_fit_BUbg(wavelengths, spec_per_kR, I_fit_kR_BUbg, fit_params_for_printing_BUbg, IDL_style_background_converted, data_unc=unc_kr_per_nm, 
-                           t=f"Fit with the BU background, int={i}", unit="kR", H_a=H_i[0], H_b=H_i[1], D_a=D_i[0], D_b=D_i[1])
+        # plot_line_fit_BUbg(wavelengths, spec_per_kR, I_fit_kR_BUbg, fit_params_for_printing_BUbg, IDL_style_background_converted, data_unc=unc_kr_idl, 
+        #                    t=f"Fit with the BU background, int={i}", unit="kR", H_a=H_i[0], H_b=H_i[1], D_a=D_i[0], D_b=D_i[1])
+        plot_line_fit_comparison(wavelengths, spec_kR_pernm, spec_per_kR, I_fit_kR_pernm, I_fit_kR_BUbg, fit_params_for_printing, 
+                                 fit_params_for_printing_BUbg, IDL_style_background_converted, unit=["kR/nm", "kR"], data_unc_new=unc_kr_per_nm, data_unc_BU=unc_kr_idl, suptitle=titletext)
         
         # Background comparison
         # ============================================================================================
@@ -2203,7 +2205,9 @@ def plot_line_fit(data_wavelengths, data_vals, model_fit, fit_params_for_printin
     pass
 
 
-def plot_line_fit_BUbg(data_wavelengths, data_vals, model_fit, fit_params_for_printing, thebackground, data_unc=None, H_a=0, H_b=0, D_a=0, D_b=0, t="Fit", unit="DN", logview=False, plot_bg=True):
+def plot_line_fit_comparison(data_wavelengths, data_vals_new, data_vals_BU, model_fit_new, model_fit_BU, fit_params_new, fit_params_BU, BUbackground, 
+                             data_unc_new=None, data_unc_BU=None, H_a=0, H_b=0, D_a=0, D_b=0, titles=["Python fit, linear background", "Python fit, Mayyasi+2023 background"], 
+                             suptitle=None, unit=None, logview=False, plot_bg=True):
     """
     Plots the fit defined by data_vals to the data, data_wavelengths and data_vals.
 
@@ -2236,60 +2240,82 @@ def plot_line_fit_BUbg(data_wavelengths, data_vals, model_fit, fit_params_for_pr
     mpl.rcParams['axes.labelsize'] = 18
     mpl.rcParams['axes.titlesize'] = 22
 
-    fig = plt.figure(figsize=(8,6))
-    mygrid = gs.GridSpec(4, 1, figure=fig, hspace=0.1)
-    mainax = plt.subplot(mygrid.new_subplotspec((0, 0), colspan=1, rowspan=3)) 
-    residax = plt.subplot(mygrid.new_subplotspec((3, 0), colspan=1, rowspan=1), sharex=mainax) 
+    fig = plt.figure(figsize=(16,6))
+    mygrid = gs.GridSpec(4, 2, figure=fig, hspace=0.1, wspace=0.1)
+    mainax_new = plt.subplot(mygrid.new_subplotspec((0, 0), colspan=1, rowspan=3)) 
+    residax_new = plt.subplot(mygrid.new_subplotspec((3, 0), colspan=1, rowspan=1), sharex=mainax_new) 
+    mainax_BU = plt.subplot(mygrid.new_subplotspec((0, 1), colspan=1, rowspan=3)) 
+    residax_BU = plt.subplot(mygrid.new_subplotspec((3, 1), colspan=1, rowspan=1), sharex=mainax_BU) 
 
-    mainax.tick_params(labelbottom=False)
-    residax.tick_params(labelbottom=True)
-    mainax.set_title(t)
+    for (t,  u, ma) in zip(titles, unit, [mainax_new, mainax_BU]):
+        ma.tick_params(labelbottom=False)
+        ma.set_title(t)
+        ma.set_xlim(min(data_wavelengths)-0.02, max(data_wavelengths)+0.02)
+        ma.set_ylabel(f"Brightness ({u})")
 
+    for ra in [residax_new, residax_BU]:
+        ra.tick_params(labelbottom=True)
+        ra.set_xlabel("Wavelength (nm)")
+
+    plt.suptitle(suptitle, y=1.05)
+    
     # Plot background fit
     if plot_bg:
-        mainax.plot(data_wavelengths, thebackground, label="background", linewidth=2, zorder=2)
+        py_lin_bg = background(data_wavelengths, fit_params_new['M'], fit_params_new['lambdac'], fit_params_new['B'])
+        mainax_new.plot(data_wavelengths, py_lin_bg, label="background", linewidth=2, zorder=2)
+        mainax_BU.plot(data_wavelengths, BUbackground, label="background", linewidth=2, zorder=2)
         
     # Plot the data and fit and a guideline for the central wavelength
-    mainax.errorbar(data_wavelengths, data_vals, yerr=data_unc, label="data", linewidth=1, zorder=3, alpha=0.7)
-    mainax.plot(data_wavelengths, model_fit, label="model", linewidth=2, zorder=2)
-    mainax.axvline(fit_params_for_printing['lambdac'], color="gray", zorder=1, linewidth=0.5, )
+    mainax_new.errorbar(data_wavelengths, data_vals_new, yerr=data_unc_new, label="data", linewidth=1, zorder=3, alpha=0.7)
+    mainax_new.plot(data_wavelengths, model_fit_new, label="model (new)", linewidth=2, zorder=2)
+    mainax_new.axvline(fit_params_new['lambdac'], color="gray", zorder=1, linewidth=0.5, )
+
+    mainax_BU.errorbar(data_wavelengths, data_vals_BU, yerr=data_unc_BU, label="data", linewidth=1, zorder=3, alpha=0.7)
+    mainax_BU.plot(data_wavelengths, model_fit_BU, label="model (BU)", linewidth=2, zorder=2)
+    mainax_BU.axvline(fit_params_BU['lambdac'], color="gray", zorder=1, linewidth=0.5, )
 
     # get index of lambda for D so we can find the value there
-    if fit_params_for_printing["lambdac_D"] is not np.nan:
-        D_i = find_nearest(data_wavelengths, fit_params_for_printing['lambdac_D'])[0]
-        mainax.axvline(fit_params_for_printing['lambdac_D'], color="gray", linewidth=0.5, zorder=1)
+    if fit_params_new["lambdac_D"] is not np.nan:
+        D_i = find_nearest(data_wavelengths, fit_params_new['lambdac_D'])[0]
+        mainax_new.axvline(fit_params_new['lambdac_D'], color="gray", linewidth=0.5, zorder=1)
+
+    if fit_params_BU["lambdac_D"] is not np.nan:
+        D_i = find_nearest(data_wavelengths, fit_params_BU['lambdac_D'])[0]
+        mainax_BU.axvline(fit_params_BU['lambdac_D'], color="gray", linewidth=0.5, zorder=1)
     
     # Print text
-    printme = [#r"H $\lambda_c$: "+f"{round(fit_params_for_printing['lambdac'], 3)}", 
-               #r"D $\lambda_c$: "+f"{round(fit_params_for_printing['lambdac_D'], 3)}",
-              ]
+    printme_new = []
+    printme_BU = []
     
     # Now subtract the background entirely from the fit and then integrate to see the total brightness
-    if "kR" in unit:
-        # background_subtracted = data_vals - thebackground
-        # Htot, Dtot = line_brightness(data_wavelengths, background_subtracted, [H_a, H_b], [D_a, D_b])
-        printme.append(f"H: {fit_params_for_printing['peakH']} kR")
-        printme.append(f"D: {fit_params_for_printing['peakD']} kR")
-        textx = [0.38, 0.28]
-        texty = [0.5, 0.17]
-        talign = ["left", "right"]
+    printme_new.append(f"H: {fit_params_new['area']} kR")
+    printme_new.append(f"D: {fit_params_new['area_D']} kR")
+    printme_BU.append(f"H: {fit_params_BU['peakH']} kR")
+    printme_BU.append(f"D: {fit_params_BU['peakD']} kR")
+    textx = [0.38, 0.28]
+    texty = [0.5, 0.17]
+    talign = ["left", "right"]
 
-    for i in range(0, len(printme)):
-        mainax.text(textx[i], texty[i], printme[i], transform=mainax.transAxes, ha=talign[i])
+    for i in range(0, len(printme_new)):
+        mainax_new.text(textx[i], texty[i], printme_new[i], transform=mainax_new.transAxes, ha=talign[i])
+        mainax_BU.text(textx[i], texty[i], printme_BU[i], transform=mainax_BU.transAxes, ha=talign[i])
 
     # ax.set_yscale("log")
-    mainax.set_ylabel(f"Brightness ({unit})")
+    residax_new.set_ylabel(f"Residuals\n (sgn((data-model)^2))")
     if logview:
-        mainax.set_yscale("log")
-    mainax.legend()
-    mainax.set_xlim(min(data_wavelengths)-0.02, max(data_wavelengths)+0.02)
+        mainax_new.set_yscale("log")
+        mainax_BU.set_yscale("log")
+    mainax_new.legend()
+    mainax_BU.legend()
 
     # Residual axis
-    sign = np.sign(model_fit-data_vals)
-    residual = sign * (data_vals - model_fit)**2
-    residax.plot(data_wavelengths, residual, linewidth=1)
-    residax.set_ylabel(f"Residuals\n (sgn((data-model)^2))")
-    residax.set_xlabel("Wavelength (nm)")
+    sign_new = np.sign(model_fit_new - data_vals_new)
+    residual_new = sign_new * (data_vals_new - model_fit_new)**2
+    residax_new.plot(data_wavelengths, residual_new, linewidth=1)
+
+    sign_BU = np.sign(model_fit_BU - data_vals_BU)
+    residual_BU = sign_BU * (data_vals_BU - model_fit_BU)**2
+    residax_BU.plot(data_wavelengths, residual_BU, linewidth=1)
     
     plt.show()
 

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -913,7 +913,7 @@ def update_index(rootpath, geospatial=False, new_files_limit_per_run=1000):
     print(f'total files to add: {new_files_to_add}')
     
     for i in range(new_files_to_add//new_files_limit_per_run + 1):
-        idx = get_dir_metadata(rootpath, new_files_limit=new_files_limit_per_run)
+        idx = get_dir_metadata(rootpath, geospatial=geospatial, new_files_limit=new_files_limit_per_run)
         # clear_output()
         print(f'total files indexed: {len(idx)}')
 

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -1053,15 +1053,16 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
             try:
                 param_uncert = np.diag(bestfit.hess_inv)
             except Exception as y:
-                print("ERROR, I haven't figured out uncertainties for methods other than Powell.")
-                raise y
+                print("Warning: Uncertainties not determined for methods other than Powell. Here are the results of the fitting algorithm:")
+                print(bestfit)
+                param_uncert = [0, 0]
 
         rel_brightness_uncert = [(param_uncert[0] / bestfit.x[0]), (param_uncert[1] / bestfit.x[1])]
 
         # Create a convenient dictionary which can be used with a plotting routine
         fit_params_for_printing = {'area': round(bestfit.x[0]), 'area_D': round(bestfit.x[1]), 
-                    'lambdac': round(bestfit.x[2], 3), 'lambdac_D': round(bestfit.x[2]-D_offset, 3), 
-                    'M': round(bestfit.x[3] ), 'B': round(bestfit.x[4])}
+                                    'lambdac': round(bestfit.x[2], 3), 'lambdac_D': round(bestfit.x[2]-D_offset, 3), 
+                                    'M': round(bestfit.x[3] ), 'B': round(bestfit.x[4])}
         
         # Construct a background array from the fit which can then be converted like the spectrum
         bg_fit = background(wavelengths, fit_params_for_printing['M'], fit_params_for_printing['lambdac'], fit_params_for_printing['B'])
@@ -1239,7 +1240,6 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
            H_brightnesses_peak_method_BUbg, D_brightnesses_peak_method_BUbg
 
           
-
 def DN_to_physical_units(light_fits, model_I, spec, unc, background_array, model_conversion):
     """
     Converts DN to physical units of kR / nm.

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -1243,7 +1243,6 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
 
           
 
-def do_conversion(light_fits, model_I, spec, unc, background_array, model_conversion, calibration="new"):
 def DN_to_physical_units(light_fits, model_I, spec, unc, background_array, model_conversion):
     """
     Converts DN to physical units of kR / nm.

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -1142,8 +1142,6 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
         # Plot fit
         # ============================================================================================
         titletext = f"Fit: Integration {i}, {re.search(uniqueID_RE, light_fits['Primary'].header['Filename'] ).group(0)}"
-        unittext_kR = "kR/nm"
-        unc_kr_per_nm = convert_spectrum_DN_to_photons(light_fits, unc)*conv_to_kR_per_nm
 
         fit_params_for_printing['area'] = round(H_kR, 2)
         fit_params_for_printing['area_D'] = round(D_kR, 2)

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -1828,6 +1828,9 @@ def get_spectrum(data, light_fits, average=False, coadded=False, integration=0):
     NOTE: This is called by both the l1a-->l1c pipeline and the quicklook maker,
     so don't get rid of the coadded functionality and think you're clever; we need
     that for the quicklooks.
+    NOTE: Although this function could operate on any detector image and produce
+    some kind of result, it is only really relevant to the orders containing the 
+    Lyman alpha emissions.
 
     Parameters:
     ----------

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -10,6 +10,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gs
 import math
+from pathlib import Path
 import re 
 import pandas as pd
 import subprocess

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -995,8 +995,6 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
     # ==============================================================================================
     H_brightnesses_from_integrating = np.empty(n_int)
     D_brightnesses_from_integrating = np.empty(n_int)
-    H_brightnesses_peak_method = np.empty(n_int) # Same as what IDL pipeline does. Ignores bin width.
-    D_brightnesses_peak_method = np.empty(n_int) # Same   as what IDL pipeline does. Ignores bin width.
     H_brightnesses_peak_method_BUbg = np.empty(n_int) # for BU background
     D_brightnesses_peak_method_BUbg = np.empty(n_int) # for BU background
     bright_data_ph_per_s = np.ndarray((n_int, get_wavelengths(light_fits).size))
@@ -1123,25 +1121,6 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
         bg_ph_s = background(wavelengths, popt[0], fit_params_for_printing['lambdac'], popt[2])
         spec_ph_s_bg_sub = spec_ph_s - bg_ph_s
         bright_data_ph_per_s[i, :] = spec_ph_s_bg_sub
-        
-        # IDL pipeline method (grab Peak brightness in kR) 
-        # ---------------------------------------------------------------------------------------------------
-        # This section is mainly here for comparison between the methods.
-        # Do all this for our method with linear background, and for the fit with BU background.
-
-        I_fit_kR = convert_spectrum_DN_to_photons(light_fits, I_fit) * conv_to_kR_with_LSFunit
-        background_array_kR = convert_spectrum_DN_to_photons(light_fits, bg_fit) * conv_to_kR_with_LSFunit
-        I_fit_kR_bg_subtracted = I_fit_kR - background_array_kR 
-
-        # Indices so we can find the peak as the IDL pipeline does
-        iHlc, Hlc = find_nearest(wavelengths, fit_params_for_printing["lambdac"])
-        iDlc, Dlc = find_nearest(wavelengths, fit_params_for_printing["lambdac_D"])
-
-        # the fitted central wavelength is not guaranteed to be perfectly matched to the indices above, 
-        # so instead of just grabbing the value at that index, we will look in the small region around that index
-        # (± 3 indices) and grab the max in that area.
-        H_brightnesses_peak_method[i] = np.max(I_fit_kR_bg_subtracted[iHlc-3:iHlc+3])
-        D_brightnesses_peak_method[i] = np.max(I_fit_kR_bg_subtracted[iDlc-3:iDlc+3])
 
         # Using the BU bg ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         I_fit_kR_BUbg = convert_spectrum_DN_to_photons(light_fits, I_fit_BUbg) * conv_to_kR_with_LSFunit
@@ -1308,7 +1287,8 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
         print("Errors: ", errs)
         print("Finished writing to IDL, I hope")
 
-    return H_brightnesses_from_integrating, D_brightnesses_from_integrating, H_brightnesses_peak_method, D_brightnesses_peak_method, H_brightnesses_peak_method_BUbg, D_brightnesses_peak_method_BUbg
+    return H_brightnesses_from_integrating, D_brightnesses_from_integrating,\
+           H_brightnesses_peak_method_BUbg, D_brightnesses_peak_method_BUbg
 
 
 # Line fitting =============================================================

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -991,7 +991,8 @@ def get_ech_slit_indices(light_fits):
 # L1c processing ===========================================================
 
 def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibration="new", solv="Powell", fitpackage="scipy", approach="dynamic", livepts=500, 
-                       clean_data=True, clean_method="new", run_writeout=True, check_background=False, plot_subtract_bg=True, plot_bg_separately=False, 
+                       clean_data=True, clean_method="new", run_writeout=True, check_background=False, plot_subtract_bg=True, plot_bg_separately=False,
+                       print_algorithm_details_on_plot=False, 
                        remove_rays=True, remove_hotpix=True,
                        idl_pipeline_folder="/home/emc/OneDrive-CU/Research/IUVS/IDL_pipeline/"):
     """
@@ -1043,6 +1044,9 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
                   if True, the remove_cosmic_rays() routine will be run.
     remove_hotpix : boolean
                     if True, the remove_hot_pixels() routine will be run.
+    print_algorithm_details_on_plot : boolean
+                                      if True, details about the solver algorithm and clean up will
+                                      be shown on the plots.
     idl_pipeline_folder : string
                           Local path of the IDL pipeline software, to which certain files will be written out 
                           to allow for the final l1c product creation via IDL called from subprocess.
@@ -1265,8 +1269,20 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
         fit_params_for_printing['uncert_D'] = D_kR_1sig
 
         # Plot in kR/nm
+        if print_algorithm_details_on_plot:
+            extra_print_on_plot = [f"Algorithm: {fitpackage}", 
+                                   f"Calibration: {calibration}",
+                                   f"Clean data: {clean_data}"]
+            if clean_data:
+                extra_print_on_plot.append(f"Clean method: {clean_method}")
+                extra_print_on_plot.append(f"Remove cosmic rays: {remove_rays}")
+                extra_print_on_plot.append(f"Remove hot pix: {remove_hotpix}")
+        else: 
+            extra_print_on_plot = []
+            
+
         echgr.plot_line_fit(wavelengths, spec_kR_pernm, I_fit_kR_pernm, fit_params_for_printing, data_unc=data_unc_kR_pernm, t=titletext,
-                            plot_bg=bg_array_kR_pernm, plot_subtract_bg=plot_subtract_bg, plot_bg_separately=plot_bg_separately)
+                            plot_bg=bg_array_kR_pernm, plot_subtract_bg=plot_subtract_bg, plot_bg_separately=plot_bg_separately, extra_print_on_plot=extra_print_on_plot)
         
         # Plot a comparison of the two methods ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         echgr.plot_line_fit_comparison(wavelengths, spec_kR_pernm, spec_kR, I_fit_kR_pernm, I_fit_kR_BUbg, fit_params_for_printing, 

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -1,6 +1,5 @@
 import datetime
 import numpy as np
-import scipy as sp
 from astropy.io import fits
 import textwrap
 import os 
@@ -26,6 +25,7 @@ from maven_iuvs.geometry import has_geometry_pvec
 from maven_iuvs.search import get_latest_files, find_files
 from maven_iuvs.integration import get_avg_pixel_count_rate
 
+from maven_iuvs.instrument import ech_Lya_slit_start, ech_Lya_slit_end
 
 # WEEKLY REPORT CODE ==================================================
 
@@ -252,63 +252,29 @@ def downselect_data(light_index, orbit=None, date=None, segment=None):
 # Relating to dark vs. light observations -----------------------------
 
 
-def coadd_lights(light_fits, dark_fits, return_bad_inds=True, clean_data=True, median=False):
+def coadd_lights(data, n_good):
     """
     Co-add all light frames within light_fits, including subtraction
     of dark frames in dark_fits.
 
     Parameters
     ----------
-    light_fits : astropy.io.fits instance
-                 fits object representing the light observations.
-    dark_fits : astropy.io.fits instance
-                 fits object representing the associated darks.
+    data : array
+           detector image data, size (frames, spatial, wavelength)
+    n_good : int
+             number of valid frames of data used, calculated by subtract_darks.
 
     Returns
     ----------
     coadded_lights : array
                      Essentially the mean-frame of the detector
-    nan_light_inds : array
-                     Indices of light frames in which there are nan values.
-    bad_light_inds : array
-                     Indices of light frames in which there are bad values (not nans)
-    nan_dark_inds : array
-                    Indices of dark frames in which there are nans.
-    total_frames : int
-                   total number of good frames which were used to create the 
-                   co-added image. Returned so the value can be added to 
-                   quicklooks.
     """
-
-    # dark subtraction
-    data, total_good_frames, bad_inds = subtract_darks(light_fits, dark_fits)
-
-    # CLean it up - this shuld be moved out 
-    if clean_data:
-        mask = get_lya_mask(data, light_fits)
-        data = remove_hot_pixels(remove_cosmic_rays(data, mask), mask)
 
     # Do the co-adding
-    if median:
-        coadded_lights = np.nanmedian(data, axis=0)
-    else:
-        coadded_lights = np.nansum(data, axis=0) / total_good_frames
+    coadded_lights = np.nansum(data, axis=0)
 
     # return everything necessary; this basically returns an average frame (because it divides by total frames used).
-    if return_bad_inds:
-        return coadded_lights, total_good_frames, bad_inds
-    else:
-        return coadded_lights, total_good_frames
-
-
-def median_light_frame(light_fits, dark_fits):
-    """
-    Obtains a median light frame, which can be useful for displaying the observations without cosmic rays, etc.
-    """
-    dark_subtracted, nan_light_inds, bad_light_inds, nan_dark_inds = subtract_darks(light_fits, dark_fits)
-    medframe = np.nanmedian(dark_subtracted, axis=0)
-
-    return medframe
+    return coadded_lights / n_good
 
 
 def subtract_darks(light_fits, dark_fits):

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -1,17 +1,31 @@
 import datetime
 import numpy as np
+import scipy as sp
 from astropy.io import fits
 import textwrap
 import os 
 import copy
-from maven_iuvs.binning import get_binning_scheme, pix_to_bin
+import skimage as ski
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as gs
+import math
+import re 
+import pandas as pd
+import subprocess
+from numpy.lib.stride_tricks import sliding_window_view
+from maven_iuvs.binning import get_binning_scheme
+from maven_iuvs.constants import D_offset
+# from maven_iuvs.graphics.echelle_graphics import plot_line_fit
+from maven_iuvs.instrument import ech_LSF_unit, convert_spectrum_DN_to_photons, \
+                                   get_ech_slit_indices, ech_Lya_slit_start, ech_Lya_slit_end, \
+                                   mcp_dn_to_volt, mcp_volt_to_gain
 from maven_iuvs.miscellaneous import get_n_int, locate_missing_frames, \
-    iuvs_orbno_from_fname, iuvs_filename_to_datetime, iuvs_segment_from_fname
+    iuvs_orbno_from_fname, iuvs_filename_to_datetime, iuvs_segment_from_fname, \
+    uniqueID_RE, find_nearest
 from maven_iuvs.geometry import has_geometry_pvec
 from maven_iuvs.search import get_latest_files, find_files
 from maven_iuvs.integration import get_avg_pixel_count_rate
 
-from maven_iuvs.instrument import ech_Lya_slit_start, ech_Lya_slit_end
 
 # WEEKLY REPORT CODE ==================================================
 
@@ -59,7 +73,7 @@ def weekly_echelle_report(weeks_before_now_to_report, root_folder):
 
     geom_files = find_files_with_geometry(weekly_report_idx)
     try:
-        latest_orbit_with_geometry = iuvs_orbno_from_fname(geom_files[-1])
+        latest_orbit_with_geometry = iuvs_orbno_from_fname(geom_files[-1]['name'])
         print(f"Geometry available through --> orbit {latest_orbit_with_geometry} ({iuvs_filename_to_datetime(geom_files[-1]['name']).isoformat()[:10]})")
     except IndexError:
         print(f"Geometry not available after orbit {iuvs_orbno_from_fname(weekly_report_idx[0]['name'])}. ")
@@ -187,7 +201,6 @@ def downselect_data(light_index, orbit=None, date=None, segment=None):
     # First filter by segment; a given segment can occur on many dates and many orbits
     if segment is not None:
         selected_lights = [entry for entry in selected_lights if iuvs_segment_from_fname(entry['name'])==segment]
-        print("")
 
     # Then filter by orbit, since orbits sometimes cross over day boundaries
     if orbit is not None: 
@@ -239,7 +252,7 @@ def downselect_data(light_index, orbit=None, date=None, segment=None):
 # Relating to dark vs. light observations -----------------------------
 
 
-def coadd_lights(light_fits, dark_fits, return_bad_inds=True):
+def coadd_lights(light_fits, dark_fits, return_bad_inds=True, clean_data=True, median=False):
     """
     Co-add all light frames within light_fits, including subtraction
     of dark frames in dark_fits.
@@ -268,16 +281,24 @@ def coadd_lights(light_fits, dark_fits, return_bad_inds=True):
     """
 
     # dark subtraction
-    data_dark_subtracted, total_good_frames, bad_inds = subtract_darks(light_fits, dark_fits)
+    data, total_good_frames, bad_inds = subtract_darks(light_fits, dark_fits)
+
+    # CLean it up - this shuld be moved out 
+    if clean_data:
+        mask = get_lya_mask(data, light_fits)
+        data = remove_hot_pixels(remove_cosmic_rays(data, mask), mask)
 
     # Do the co-adding
-    coadded_lights = np.nansum(data_dark_subtracted, axis=0)
+    if median:
+        coadded_lights = np.nanmedian(data, axis=0)
+    else:
+        coadded_lights = np.nansum(data, axis=0) / total_good_frames
 
     # return everything necessary; this basically returns an average frame (because it divides by total frames used).
     if return_bad_inds:
-        return coadded_lights / total_good_frames, total_good_frames, bad_inds
+        return coadded_lights, total_good_frames, bad_inds
     else:
-        return coadded_lights / total_good_frames, total_good_frames
+        return coadded_lights, total_good_frames
 
 
 def subtract_darks(light_fits, dark_fits):
@@ -841,3 +862,972 @@ def find_files_with_geometry(file_index):
     # print(f'{len(with_geom)} have geometry.\n')
     return with_geom
 
+# L1c processing ===========================================================
+
+def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, solv="Powell", clean_data=True):
+    """
+    Converts a single l1a echelle observation to l1c. At present, two .csv files containing some 
+    quantities that need to be written out to the .fits file are generated and saved, and IDL is 
+    called using subprocess. This means that every time this function is called, IDL must load and 
+    compile all required modules, i.e. all of the MAVEN software including SPICE kernels, which takes
+    a long time. In a future update, this code and a future wrapper function should be modified so that
+    IDL is only opened once before writing out multiple files.
+
+    Parameters
+    ----------
+    light_fits : astropy.io.fits instance
+                File with light observation
+    dark_fits : astropy.io.fits instance
+                File with associated darks for light_fits
+    light_l1a_path : string
+                     Pathname for the source l1a file. This is needed for IDL writeout purposes.
+    savepath : string
+               Parent folder in which to save the resulting l1c file. 
+    solv : string
+        Name of the fitting routine to use with scipy.optimize.minimize.
+    clean_data : boolean
+                 Whether to perform cosmic ray removal and hot pixel adjustment.
+
+    Returns
+    ----------
+    some sort of file to be sent to IDL (TODO: fix this comment)
+    """
+    # Certain detector parameters
+    # --------------------------------------------------------------------------------------------
+    # This is used to get the right indices for MRH and SZA, etc. Taken straight from IDL.
+    binning_df = pd.DataFrame({  
+                                "Nspa": [18, 50, 159, 92, 64, 74, 1024],
+                                "Nspe": [201, 160, 160, 512, 384, 332, 1024],
+                                "NbinsY": [38, 11, 5, 11, 11, 11, 1], 
+                                "xcH": [178, 261, 260, 0, 256, 256, 0],
+                                "ycH": [310, 299, 229, 5, 313, 203, 0],
+                                "aprow1": [1, 4, 23, 31, 3, 13, 346],
+                                "aprow2": [6, 21, 61, 48, 20, 30, 535],
+                                "noise_lo_lim": [8, 8, 8, 25, 10, 10, 8],
+                                "noise_hi_lim": [42, 28, 28, 60, 37, 30, 42],
+                                "back_rows_arr": [[0, 1-1, 6+1, 6+1], 
+                                                [0, 4-1, 21+3, 21+5], 
+                                                [0, 23-1, 61+5, 61+11],
+                                                [27, 31-1, 48+3, 48+5], 
+                                                [0, 3-1, 20+3, 20+5], 
+                                                [0, 13-1, 30+3, 30+5], 
+                                                [27, 346-11, 535+11, 535+43]]
+                            })   
+
+    # Load the LSF
+    # --------------------------------------------------------------------------------------------
+    lsf_new = sp.io.readsav("../IDL_pipeline/lsf_new.idl", idict=None, python_dict=False)
+    lsfx_nm = lsf_new["echw"] / 10 # convert wavelength to nm, not angstrom
+
+    # Number of integrations and integration time ------------------------------------------------
+    n_int = get_n_int(light_fits)
+    t_int = light_fits["Primary"].header["INT_TIME"]  
+
+    # Dark subtraction and data cleanup ----------------------------------------------------------
+    data, n_good, i_bad = subtract_darks(light_fits, dark_fits)
+    
+    if clean_data is True:
+        data = remove_cosmic_rays(data)
+        data = remove_hot_pixels(data)
+
+    # Arrays to store brightness values 
+    H_brightnesses_from_integrating = np.empty(n_int)
+    D_brightnesses_from_integrating = np.empty(n_int)
+    H_brightnesses_peak_method = np.empty(n_int) # Same as what IDL pipeline does. Ignores bin width.
+    D_brightnesses_peak_method = np.empty(n_int) # Same   as what IDL pipeline does. Ignores bin width.
+    bright_data_ph_per_s = np.ndarray((n_int, get_wavelengths(light_fits).size))
+
+    # Wavelengths and binwidths (which typically don't change)
+    wavelengths = get_wavelengths(light_fits)
+    binwidth_nm = dx_array(wavelengths)
+
+    # Conversion factors
+    Aeff =  32.327455  # Acquired by testing on one file. TODO: Check if this needs to change with each file. 
+    conv_to_kR_with_LSFunit = ech_LSF_unit / (t_int)
+    conv_to_kR_per_nm = 1 / (t_int * binwidth_nm * Aeff)
+    conv_to_kR = 1 / (t_int * Aeff)
+
+    # Uncertainty on the data ---------------------------------------------------------------------------
+    # Let's start by just wholesale adapting the uncertainty calculation from Matteo in the IDL pipeline and see what it looks like.
+    # In progress
+    volt = mcp_volt_to_gain(mcp_dn_to_volt(light_fits['Engineering'].data['MCP_GAIN'][0]), channel="FUV")
+    n_bins = light_fits['primary'].header['spe_size'] * light_fits['primary'].header['spa_size'] # in a square bin of spatial x spectral. works out to 22.
+    sigma_background = 4313 * math.sqrt(t_int/60) * math.sqrt(n_bins/480.)/(2**((850-volt)/50.))
+    fit_function = 40 / (2**((700-volt)/50))
+    
+    # This is the correct shape, not sure if it's reasonable values though:
+    ran_DN = np.sqrt(data * fit_function + sigma_background**2) # NOTE: check if it's okay to do this on the cleaned data. Probably not
+    ran_DN[np.where(np.isnan(ran_DN))] = 0 # TODO: this is not acceptable lol
+
+    for i in range(n_int): # Loop over integrations
+        # print(f"Working on integration {i}")
+        # Acquire the spatially-added spectrum and uncertainties
+        # ---------------------------------------------------------------------------------------------------
+        spec = get_spectrum(data, light_fits, integration=i)  
+        unc = add_in_quadrature(ran_DN, light_fits, integration=i) 
+
+        # Generate the CLSF from the LSF
+        # ---------------------------------------------------------------------------------------------------
+        theCLSF = CLSF_from_LSF(lsf_new["echf"], LSFx=lsfx_nm)
+
+        # PERFORM FIT
+        # ---------------------------------------------------------------------------------------------------
+        # Through experimentation, we found that the best solvers to use are in descending order: 
+        # Powell, Nelder-Mead, and then TNC, CG, L-BFGS-B,and trust-constr are all kinda similar
+        H_i = [20, 170] # Range for integrating H and D. 
+        D_i = [80, 100]
+        initial_guess = line_fit_initial_guess(wavelengths, spec, H_a=H_i[0], H_b=H_i[1], D_a=D_i[0], D_b=D_i[1]) 
+        bestfit, I_fit = fit_line(initial_guess, wavelengths, spec, light_fits, theCLSF, unc=unc, solver=solv) 
+
+        # Create a convenient dictionary which can be used with a plotting routine
+        fit_params_for_printing = {'area': round(bestfit.x[0]), 'area_D': round(bestfit.x[1]), 
+                    'lambdac': round(bestfit.x[2], 3), 'lambdac_D': round(bestfit.x[2]-D_offset, 3), 
+                    'M': round(bestfit.x[3] ), 'B': round(bestfit.x[4])}
+    
+        # Construct a background array from the fit which can then be converted like the spectrum
+        bg_fit = background(wavelengths, fit_params_for_printing['M'], fit_params_for_printing['lambdac'], fit_params_for_printing['B'])
+
+        # The l1c files keep track of the spectra in "photons per second" which is the spectrum with background subtracted,
+        # so we have to also. This is per integration so we don't need n.
+        spec_ph_s = convert_spectrum_DN_to_photons(light_fits, spec) / (t_int)
+        background_array_ph_s = convert_spectrum_DN_to_photons(light_fits, bg_fit) / (t_int)
+        popt, pcov = sp.optimize.curve_fit(background, wavelengths, background_array_ph_s, p0=[-1, 121.567, 1], 
+                                           bounds=([-np.inf, 121.5, 0], [np.inf, 121.6, 50]))
+        bg_ph_s = background(wavelengths, popt[0], fit_params_for_printing['lambdac'], popt[2])
+        spec_ph_s_bg_sub = spec_ph_s - bg_ph_s
+        bright_data_ph_per_s[i, :] = spec_ph_s_bg_sub
+        
+        # IDL pipeline method (grab Peak brightness in kR) 
+        # ---------------------------------------------------------------------------------------------------
+        # This section is mainly here for comparison between the methods.
+
+        I_fit_kR = convert_spectrum_DN_to_photons(light_fits, I_fit) * conv_to_kR_with_LSFunit
+        background_array_kR = convert_spectrum_DN_to_photons(light_fits, bg_fit) * conv_to_kR_with_LSFunit
+        I_fit_kR_bg_subtracted = I_fit_kR - background_array_kR 
+
+        # Indices so we can find the peak as the IDL pipeline does
+        iHlc, Hlc = find_nearest(wavelengths, fit_params_for_printing["lambdac"])
+        iDlc, Dlc = find_nearest(wavelengths, fit_params_for_printing["lambdac_D"])
+
+        # the fitted central wavelength is not guaranteed to be perfectly matched to the indices above, 
+        # so instead of just grabbing the value at that index, we will look in the small region around that index
+        # (± 3 indices) and grab the max in that area.
+        H_brightnesses_peak_method[i] = np.max(I_fit_kR_bg_subtracted[iHlc-3:iHlc+3])
+        D_brightnesses_peak_method[i] = np.max(I_fit_kR_bg_subtracted[iDlc-3:iDlc+3])
+
+        # Our Python method: Line integrated brightness  
+        # ---------------------------------------------------------------------------------------------------
+        # Here we convert to kR/nm so that we can make a plot
+        I_fit_kR_pernm = convert_spectrum_DN_to_photons(light_fits, I_fit) * conv_to_kR_per_nm
+        spec_kR_pernm = convert_spectrum_DN_to_photons(light_fits, spec) * conv_to_kR_per_nm
+        # We can't convert the fit parameters (slope and intercept), so instead we convert the background
+        # array. In order to plot the background, we then fit that array once it's in the right units to 
+        # get the converted slope and intercept.
+        background_array = convert_spectrum_DN_to_photons(light_fits, bg_fit) * conv_to_kR_per_nm
+        popt, pcov = sp.optimize.curve_fit(background, wavelengths, background_array, p0=[-24, 121.567, 20], 
+                                           bounds=([-np.inf, 121.5, 0], [np.inf, 121.6, 500]))
+        fit_params_for_printing['M'] = popt[0]
+        fit_params_for_printing['B'] = popt[2]
+    
+        # Retrieve integrated brightnesses (these are the integrated areas under the emissions, 
+        # already retrieved in the fitting procedure). Because they are already in total DN, 
+        # we don't need to include a 1/nm factor here. 
+        H_kR = convert_spectrum_DN_to_photons(light_fits, bestfit.x[0]) * conv_to_kR 
+        D_kR = convert_spectrum_DN_to_photons(light_fits, bestfit.x[1]) * conv_to_kR 
+
+        # Append the brightnesses for this integration to the output arrays
+        H_brightnesses_from_integrating[i] = H_kR
+        D_brightnesses_from_integrating[i] = D_kR
+        
+        # Plot fit
+        # ---------------------------------------------------------------------------------------------------
+        titletext = f"Fit: Integration {i}, {re.search(uniqueID_RE, light_fits['Primary'].header['Filename'] ).group(0)}"
+        unittext_kR = "kR/nm"
+        unc_kr_per_nm = convert_spectrum_DN_to_photons(light_fits, unc)*conv_to_kR_per_nm
+
+        fit_params_for_printing['area'] = round(H_kR, 2)
+        fit_params_for_printing['area_D'] = round(D_kR, 2)
+
+        # Plot in kR/sec/nm
+        plot_line_fit(wavelengths, spec_kR_pernm, I_fit_kR_pernm, fit_params_for_printing, data_unc=unc_kr_per_nm, t=titletext, unit=unittext_kR, 
+                      H_a=H_i[0], H_b=H_i[1], D_a=D_i[0], D_b=D_i[1] )
+        
+    
+    # Prepare results to be sent to IDL for file writeout 
+    # ============================================================================================
+
+    # Mostly destined for the BRIGHTNESSES HDU, but orbit_segment and product_creation_date are also needed in Observation.
+    center_idx = 4
+    this_dict = binning_df.loc[(binning_df['Nspa'] == get_binning_scheme(light_fits)["nspa"]) & (binning_df['Nspe'] == get_binning_scheme(light_fits)["nspe"])]
+    yMRH = 485 # the location of the row most-accurately representing the MRH altitudes across the aperture center (to be used by all emissions)
+    yMRH = math.floor((yMRH-this_dict['ycH'].values[0])/this_dict['NbinsY'].values[0]) #  to get an integer value liek IDL does.
+
+    thedict = {
+        "BRIGHT_H_kR": H_brightnesses_from_integrating, #  H brightness (BkR_H) in kR
+        "BRIGHT_D_kR": D_brightnesses_from_integrating, # D brightness (BkR_D) in kR
+        "BRIGHT_OneSIGMA_kR": 0 ,  # TODO: (BkR_U) in kR
+        "MRH_ALTITUDE_km": light_fits["PixelGeometry"].data["pixel_corner_mrh_alt"][:, yMRH, center_idx], # MRH in km
+        "TANGENT_SZA_deg": light_fits["PixelGeometry"].data["pixel_solar_zenith_angle"][:, yMRH], # SZA in degrees
+        "ET": light_fits["Integration"].data["ET"], 
+        "UTC": light_fits["Integration"].data["UTC"],
+        "PRODUCT_CREATION_DATE": datetime.datetime.now(datetime.timezone.utc).strftime('%Y/%j %b %d %H:%M:%S.%fUTC'), # in IDL the microseconds are only 5 digits long and 0, so idk.
+        "ORBIT_SEGMENT": iuvs_segment_from_fname(light_fits["Primary"].header['Filename']),
+    }
+
+    brightness_writeout = pd.DataFrame(dict([ (k,pd.Series(v)) for k,v in thedict.items() ]) )
+
+    # The following is the spectrum with the background subtracted as stated. It needs its own file because we need to write out 
+    # 10 different arrays. The IDL pipeline only writes out the last integration's spectrum 10 times, for some reason. 
+    # This error has been corrected in this version. 
+    bright_data_ph_per_s = pd.DataFrame(data=bright_data_ph_per_s.transpose(),    # values
+                                columns=[f"i={j}" for j in range(n_int)])  # 1st row as the column names
+    
+    # Save the output to some files that will be saved outside the Python module.
+    brightness_writeout.to_csv("../../brightness.csv", index=False)
+    bright_data_ph_per_s.to_csv("../../ph_per_s.csv", index=False)
+
+    # Now call IDL
+    os.chdir("/home/emc/OneDrive-CU/Research/IUVS/IDL_pipeline/")
+    commands = f'''
+                .com write_l1c_file_from_python.pro
+                write_l1c_file_from_python, '{light_l1a_path}', '{savepath}'
+                ''' 
+
+    proc = subprocess.Popen("idl", stdin=subprocess.PIPE, stdout=subprocess.PIPE, text="true")
+    print("IDL is now open")
+    outs, errs = proc.communicate(input=commands, timeout=600)
+    print("Output: ", outs)
+    print("Errors: ", errs)
+    print("Finished writing to IDL, I hope")
+
+    return H_brightnesses_from_integrating, D_brightnesses_from_integrating, H_brightnesses_peak_method, D_brightnesses_peak_method
+
+
+# Line fitting =============================================================
+
+
+def fit_line(param_initial_guess, wavelengths, spec, light_fits, CLSF, unc=1, solver=None):
+
+    """
+    Given an initial guess for fit parameters and observational data, this fits the model to the data 
+    and minimizes the "badness".
+
+    Parameters
+    ----------
+    param_initial_guess : list or array
+                          includes initial guess of values for each fit parameter: peak DN, central wavelengths, background offset.
+                          Peak DN and central wavelengths are passed for H and D in that order, but background is for the whole emission.
+    wavelengths : array
+            Array of wavelengths for fitting, in nm.
+    spec : array
+           spatially-added spectrum. Same size as wavelengths. 
+    light_fits : astropy.io.fits instance
+                File with light observation.
+    CLSF : array (n, 2)
+           CLSF object based on the LSF of the instrument. 
+    unc : int or array
+          uncertainty on spec. Determined in a parent function based on the l1a file.
+    solver : string
+             fitting algorithm to use, to be passed to scipy.optimize.minimize.
+   
+    Returns
+    ----------
+    bestfit : scipy.optimize.minimize result object
+              result of the fitting algorithm
+    I_bin : array
+            the simple fit of the LSF to the data, (A_H * LSF) + (A_D * LSF) + (background), encoding
+            the DN per bin.
+    
+    """
+
+    # Get bin edges in nm.
+    edges = get_bin_edges(light_fits)
+
+    # Now call the fitting routine
+    bestfit = sp.optimize.minimize(badness_of_fit, param_initial_guess, args=(wavelengths, spec, edges, CLSF, unc), method=solver)
+
+    I_bin = lineshape_model(bestfit.x, wavelengths, edges, CLSF)
+
+    return bestfit, I_bin
+
+
+def badness_of_fit(params, wavelength_data, DN_data, binedges, CLSF, uncertainty): 
+    """
+    Retrieves the model of the lineshape to fit, then evaluates the goodness (or badness) of fit. 
+    Badness will be minimized in a parent function.
+
+    Parameters
+    ----------
+    wavelength_data : array
+             wavelength that will be fit; nm 
+    DN_data : array
+              DN of the spectrum that will be fit 
+    binedges : array
+              array of bin edges for wavelengths, in nm.
+    CLSF : array (n, 2)
+          CLSF object based on the LSF of the instrument. 
+    uncertainty : int or array
+                  uncertainty on the spectrum
+    
+    Returns
+    -----------
+    badness : float
+              A single value defining the badness of the fit to the data, to be minimized.
+    """
+    
+    # Generate a model fit based on the given parameters
+    DN_fit = lineshape_model(params, wavelength_data, binedges, CLSF) 
+
+    # Fit the model to the existing data assuming Gaussian distributed photo events 
+    # TODO: Improve what is used here for Poisson distribution
+    badness = np.sum((DN_fit - DN_data)**2 / uncertainty)
+
+    return badness
+
+
+def lineshape_model(params, wavelength_data, binedges, theCLSF):
+    """
+    Builds the line shape model of the form:
+    (A_H * LSF) + (A_D * LSF) + (Background)
+
+    Parameters:
+    -----------
+    params : list
+            parameters of the model line shape to attempt to fit
+    wavelength_data : array
+                      observation independent variable (currently assumed to be wavelength)
+    binedges : array
+               array of bin edges for wavelengths, in nm.
+    theCLSF : array
+              the cumulative line spread function for the LSF
+
+    Returns:
+    ----------
+    I_bin : array
+            brightness per bin 
+
+    """
+    total_brightness_H = params[0] # Integrated - DN
+    total_brightness_D = params[1] # Integrated - DN
+    central_wavelength_H = params[2] # nm
+    central_wavelength_D = params[2] - D_offset # nm
+    background_m = params[3]
+    background_b = params[4]
+
+    # Interpolate the CLSF for a given attempted central wavelength 
+    interpolated_CLSF_H = interpolate_CLSF(central_wavelength_H, binedges, theCLSF)
+    interpolated_CLSF_D = interpolate_CLSF(central_wavelength_D, binedges, theCLSF)
+    
+    # Get the fraction of light per bin using the fundamental theorem of calculus on the interpolated CLSF.
+    frac_per_bin_H = np.diff(interpolated_CLSF_H) # Unitless
+    frac_per_bin_D = np.diff(interpolated_CLSF_D) # Unitless
+
+    normalized_line_shape_H = frac_per_bin_H 
+    normalized_line_shape_D = frac_per_bin_D
+
+    # Return the flux per bin
+    I_bin = (total_brightness_H * normalized_line_shape_H + 
+             total_brightness_D * normalized_line_shape_D +
+             background(wavelength_data, background_m, central_wavelength_H, background_b)
+            )
+
+    return I_bin
+
+
+def background(lamda, m, lamda_c, b):
+    """
+    Construct the functional form of the background emissions for the detector, given the parameters controlling it. 
+    Currently just a linear fit. Separated out so it can be called in more than one place.
+
+    Parameters
+    ----------
+    m : float
+        Slope of the line. 
+    lamda_c : float
+        Central wavelength of Lyman alpha, to set the intercept to occur closer to where the emissions do. 
+    b : float
+        Constant term to determine y-difference from 0.
+    lamda : array
+        array of wavelengths.
+
+    Returns
+    ----------
+    Array of DN per wavelength for the background.
+    """
+    return (m * (lamda - lamda_c) + b)
+
+
+def interpolate_CLSF(lambda_c, binedges, CLSF): #
+    """
+    Given a particular lambda_c, this function computes the CLSF as a 
+    function of dlambda = x-lambda_c, where x is the observational data
+    and LSF_x is the x points defined for the instrument LSF. This is because
+    the instrument LSF is defined by delta lambda, the difference from the 
+    central wavelength of the emission. Finally, the computed CLSF is inteprolated
+    at the bin edges. 
+
+    TODO: This function will eventually have to be modified to accept the bin edges from the
+    actual instrument rather than just making it up, but currently the recorded bin widths 
+    are for the standard resolution mode, not the echelle mode. 
+    
+    Parameters
+    ----------
+    lambda_c : float
+               a single wavelength in nm, candidate for a possible central wavelength marking the location of the emission peak.
+    bin_edges : array
+                Defines the bin edges in nm on which the LSF will be interpolated
+    CLSF : array
+           CLSF computed from the LSF in question, result of CLSF_from_LSF.
+
+    Returns
+    ----------
+    interp_CLSF : array
+                  the same CLSF reinterpolated on bin_edges.
+    """
+  
+    # Shift the wavelengths of the bin centers and edges
+    dlambda_binedges = binedges - lambda_c
+    
+    # Ensure that CLSF x is increasing everywhere so interp doesn't have meaningless results
+    if any(np.diff(CLSF) < 0):
+        raise Exception("ValueError: Can't interpolate because x values are not monotonically increasing")
+
+    interp_CLSF = np.interp(dlambda_binedges, CLSF[:, 0], CLSF[:, 1], left=0, right=1) 
+
+    # For some reason, interp function isn't automatically setting the edges to the requested values
+    if any(interp_CLSF > 1):
+        interp_CLSF[np.where(interp_CLSF > 1)] = 1
+
+    return interp_CLSF
+    
+
+def CLSF_from_LSF(LSFy, LSFx=None, dx=None):
+    """
+    Compute the empirical CLSF, given some LSF defined by xdata and ydata.
+    
+    Parameters
+    ----------
+    LSFy, LSFx : arrays
+                 x and y points which define the instrument LSF.
+    dx : real (float or int)
+         difference between consecutive x values. If not provided, will be calculated from xdata.
+
+    Returns
+    ----------
+    cumulative : array
+                 The CLSF, valid at the same xdata.
+    """
+
+    # The LSF usually comes in angstroms, and covers ± ~3 Å; put it in nm.
+    if 1 <= np.max(LSFx)<= 4:
+        LSFx = LSFx / 10
+
+    if dx is None:
+        if LSFx is None:
+            raise Exception("Please specify xdata or dx")
+        else:
+            dx = dx_array(LSFx) # Generate the dx array, since wavelengths are not equally spaced.
+        
+    cumulative = np.zeros((len(LSFx), 2))
+    
+    cumulative[:, 0] = LSFx
+    cumulative[:, 1] = np.cumsum(LSFy) * dx
+
+    # Normalize it so it asymptotes to 1.
+    cumulative[:, 1] = cumulative[:, 1] / cumulative[cumulative.shape[0]-1, 1]
+
+    return cumulative
+
+
+def get_spectrum(data, light_fits, average=False, coadded=False, integration=0): 
+    """
+    Produces a spectrum averaged along the spatial dimension of the slit 
+    NOTE: This is called by both the l1a-->l1c pipeline and the quicklook maker,
+    so don't get rid of the coadded functionality and think you're clever; we need
+    that for the quicklooks.
+
+    Parameters:
+    ----------
+    data : array
+           3D numpy array of image detector data, dark subtracted and cleaned. 
+    light_fits : astropy.io.fits instance
+                 File with light observation
+    average : boolean
+              whether to get the average spectrum across the slit, False by default.
+    coadded : boolean
+              If True, will get a spectrum averaged across integrations. If False, 
+              will only get the spectrum for one detector frame at a time.
+    integration : int
+                  Integration frame to use for the specrum. Used if coadded=False.
+    clean_data : boolean 
+                 whether to perform the data cleaning routines
+
+    Returns:
+    ----------
+    spectrum : array
+               Spectrum in total DN summed over the spatial dimension
+    
+    """
+    # Collect pixel range which we need to find the slit start and end 
+    si1, si2 = get_ech_slit_indices(light_fits)
+
+    if coadded:
+        spectrum = np.sum(data[si1:si2, :], axis=0)
+    else:
+        # Sum up the spectra over the range in which Ly alpha is visible on the slit (not outside it)
+        # This spectrum is thus in DN
+        spectrum = np.sum(data[integration, si1:si2, :], axis=0)
+        
+    if average:
+        spectrum = spectrum / (si2 - si1)
+
+    return spectrum
+
+
+def add_in_quadrature(uncertainties, light_fits, integration=0): 
+    """
+    Similar to get_spectrum, but adds up the uncertainties in what is hopefully 
+    the correct manner. 
+
+    Parameters:
+    ----------
+    data : array
+           3D numpy array of image detector data, dark subtracted and cleaned. 
+    light_fits : astropy.io.fits instance
+                 File with light observation
+    integration : int
+                  Integration frame to use for the specrum. Used if coadded=False.
+    clean_data : boolean 
+                 whether to perform the data cleaning routines
+
+    Returns:
+    ----------
+    spectrum : array
+               Spectrum in total DN summed over the spatial dimension
+    
+    """
+    # Collect pixel range which we need to find the slit start and end 
+    si1, si2 = get_ech_slit_indices(light_fits)
+
+    total_uncert = np.sqrt( np.sum( (uncertainties[integration, si1:si2, :])**2, axis=0) )
+
+    return total_uncert
+
+
+def get_wavelengths(light_fits):
+    """
+    Retrieves wavelengths for use from a given light file. This is done in more than one place,
+    so it was useful to make a dedicated function.
+
+    Parameters:
+    -----------
+    light_fits : astropy.io.fits instance
+                 File with light observation
+
+    Returns:
+    -----------
+    wavelength array as defined in the light_fits file.
+    """
+
+    # TODO: build in code that will account for the possible case where wavelengths shift per integration
+    return light_fits["Observation"].data["Wavelength"][0, 1, :]
+
+
+def get_bin_edges(light_fits):
+    """
+    Wavelengths as defined in the fits files are defined for the bin centers.
+    This function will calculate where the bin edges should be, since the 
+    recorded bin edges in the files are all for the standard resolution mode, 
+    and not able to be applied to echelle.
+    TODO: The method used here is probably "good enough" but could be improved.
+
+    Parameters:
+    -----------
+    light_fits : astropy.io.fits instance
+                 File with light observation
+    Returns:
+    -----------
+    edges : array
+            Defines the edges of the bins for the wavelengths, so we can calculate the flux
+            to assign to the bins.
+    """    
+
+    # Grab the wavelengths 
+    wavelengths = get_wavelengths(light_fits)
+
+    # First calculate the differences between all points x
+    dlambda = np.diff(wavelengths)
+    
+    # There will be one more bin edge than x points
+    edges = np.zeros(len(wavelengths) + 1)
+
+    # Handle the left edge
+    edges[0] = wavelengths[0] - (dlambda[0] / 2) 
+
+    # inner elements
+    for i in range(1, len(edges)-1):
+        edges[i] = wavelengths[i] - dlambda[i-1] / 2
+
+    # And the right edge
+    edges[-1] = wavelengths[-1] + dlambda[-1] / 2
+    
+    return edges
+
+
+def dx_array(x):
+    """
+    Given an array x of non-evenly-spaced x values, this will calculate the 
+    dx for all of them, i.e. the value to use for dx at each point within x
+    if you want to integrate over the domain defined by x.
+
+    Parameters
+    ----------
+    x : array
+        an array of non-evenly-spaced floats.
+
+    Returns
+    ----------
+    dx : array
+         an array of the same length as x, giving the dx to use for each x_i for integration purposes.
+    """
+    # First calculate the differences between all points x
+    x_diffs = np.diff(x)
+    dx = np.zeros_like(x)
+    
+    # At left edge, we only have the difference between the x_0 and x_1 to work with, so we assume dx for x0 is symmetric about x0 and equal to x_1-x_0.
+    dx[0] = x_diffs[0]
+
+    # For other points within the domain, we adjust the bin width based on the difference of point x_i with point x_i-1 and point x_i+1.
+    for i in range(1, len(dx)-1):
+        dx[i] = 0.5*x_diffs[i-1] + 0.5*x_diffs[i]
+
+    # At the right edge, it's a similar situation to the left edge, but mirrored.
+    dx[-1] = x_diffs[-1]
+    
+    if len(x)!=len(dx):
+        raise Exception("Lengths are wrong")
+    return dx
+
+
+def line_fit_initial_guess(wavelengths, spectrum, H_a=95, H_b=135, D_a=80, D_b=100):
+    """
+    Parameters
+    ----------
+    spectrum : array
+                Data in DN/sec/px 
+    a, b : int
+            indices in the spectrum over which to integrate to get an initial guess 
+            at total flux of the line.
+    Returns
+    ----------
+    Vector of initial guess values
+    """
+
+    # Total flux of H and D initial guess: get by integrating around the line. Note that the H bounds as defined
+    # in a parent function overlap the D, but that's okay for an initial guess.
+    DN_H_guess = sp.integrate.simpson(spectrum[H_a:H_b], x=wavelengths[H_a:H_b]) # Mike said 400 is a good approx..
+    DN_D_guess = sp.integrate.simpson(spectrum[D_a:D_b], x=wavelengths[D_a:D_b])
+
+    # central wavelength initial guess - go with the canonical values
+    lambda_H_lya_guess = 121.567
+    lambda_D_lya_guess = 121.534
+
+    # Background initial guess: assume a form y = mx + b. If m = 0, assume a constant offset.
+    bg_m_guess = 0
+    bg_b_guess = np.median(spectrum)
+
+    return [DN_H_guess, DN_D_guess, lambda_H_lya_guess, lambda_D_lya_guess, bg_m_guess, bg_b_guess]
+
+# Cosmic ray and hot pixel removal -------------------------------------------
+
+
+def get_lya_mask(datacube, light_fits):
+    """
+    Construct a mask for the Lyman alpha region to be used when cleaning up data. 
+    This is not a particularly good approach and tends to ruin the spectra shape, so this should probably be retired.
+    This also isn't currently used because the hot pixel routine is working ok and not deleting real emissions.
+
+    Parameters
+    ----------
+    datacube : array (3D)
+               Detector image array in (integrations, spatial bins, spectral bins)
+    light_fits : astropy.io.fits instance
+                 fits object representing the light observations.
+    Returns
+    ----------
+    mask : masked array
+    """
+    mask = np.zeros_like(datacube[0, :, :]) # only needs to be 2D.
+    si1, si2 = get_ech_slit_indices(light_fits) # slit
+    wi = np.asarray(np.where(np.logical_and(get_wavelengths(light_fits)>=121.53, get_wavelengths(light_fits)<=121.58)))[0]
+    mask[si1:si2+1, wi] = 1 
+    return mask
+
+
+def remove_cosmic_rays(data, mask=None, Ns=2): 
+    """
+    Removes cosmic rays from the detector image by stacking images and setting any pixel
+    which is outside the median ± Ns*sigma to the median value.
+
+    Parameters
+    ----------
+    data : Array (integrations, spatial bins, spectral bins)
+           All detector images for a given observation
+    themask : masked array
+              Mask shape to use for masking out lyman alpha.
+    Ns : int
+         number of sigma to constrain stacked-frame filtering
+    """
+    Nfr = data.shape[0]  # frames (integrations)
+    Nsp = data.shape[1]  # Spatial bins
+    Nw = data.shape[2]   # Wavelength bins
+
+    # Try winsorization before computing the median, to ensure it's robust
+    # Currently not implemented but should try again.
+    # sp.stats.mstats.winsorize(data, limits=(0, 0.01), inclusive=(True, True), inplace=True, nan_policy='raise')
+    
+    # this section looks across frames for any pixels that are outside the median+Ns*sigma. 
+    # pixels that are outside that range are set to the median value. 
+    medval = np.median(data, axis=0)
+    sigma = np.std(data, axis=0, ddof=1) # ddof = 1 is required to match the result of this calculation from IDL. This sets the normalization constant of the variance to 1/(N-1)
+    
+    no_rays = copy.deepcopy(data)
+    
+    for f in range(data.shape[0]):
+        if mask is not None:
+            no_rays = np.ma.masked_array(data[f, :, :], mask=mask) # Ignore roughly the region around Lyman alph. This is really kludgy and doesn't work great
+        
+        ray_pixels = np.ma.where((no_rays[:, :] > medval+Ns*sigma) | (no_rays[:, :] < medval-Ns*sigma))
+
+        # Create coordinate lists for where the rays exist
+        coord = list(zip(ray_pixels[0], ray_pixels[1]))
+
+        # Set any pixels matching the ray coordinates to median
+        for c in coord:
+            no_rays[f, c[0], c[1]] = medval[c[0], c[1]]
+
+    return no_rays
+
+
+def remove_hot_pixels(data, mask=None, Wdt=3, Ns=3):
+    """
+    Removes hot pixels from the data by calculating the median pixel value in a 7x7 surrounding box 
+    at every pixel, and setting the central pixel to the median value if it is outside the median ± 3σ
+    within the box, where σ is the standard deviation.
+
+    Parameters
+    ----------
+    data : Array (integrations, spatial bins, wavelength bins)
+           All detector images for a given observation
+    themask : masked array
+              Mask shape to use for masking out lyman alpha.
+    Wdt : int
+          Width of the box used for single-frame median filtering
+    Ns : int
+         number of sigma to constrain single-frame filtering
+
+    Returns
+    ----------
+    no_hotp : Array (integrations, spatial bins, wavelength bins)
+              Detector image with hot pixels removed
+    """
+    Nfr = data.shape[0]  # frames (integrations)
+
+    window_edge = 2*Wdt + 1
+    no_hotp = data.astype(int, copy=False)
+
+    # Transform to integers, required by scikit-image.
+    data = data.astype("int")
+    
+    # here we are looking for the hot pixels. we find these by seeing if any pixels are anomalously larger than nearby px.
+    # the nearby pixels are defined by a 7x7 box (3 on one side, 3 on the other). 
+    # Note that as in IDL pipeline, this is done after cosmic rays are removed which may introduce some weirdness?
+    for f in range(0, Nfr-1):
+        # Ignore roughly the region around Lyman alpha. This is really kludgy and doesn't work great
+        if mask is not None:
+            thisdata = np.ma.masked_array(data[f, :, :], mask=mask) 
+        else:
+            thisdata = data[f, :, :]
+
+        # First task is to compute the difference of every pixel from the median of a 7x7 box centered on that pixel: -------------
+        # First, at every pixel, get the median value in a window_edge x window_edge sliding window centered on each pixel.
+        Fmed = ski.filters.median(thisdata[:, :], footprint=np.ones((window_edge, window_edge)), mode="nearest")
+        # NOTE: Behavior="rank" was used when I first wrote this, but it causes the median to be calculated as 0 for some reason. do not use.
+ 
+        # subtract it from every single pixel in the image.
+        Fdif = thisdata - Fmed
+        
+        # Then: -----------------------------------------------------------------------------
+        # Calculate, at each pixel in image: sqrt( sum((M-Fmed)^2) / (window_edge^2))
+        # Where M is the array defined by the sliding window and Fmed is as before.
+        # There seem to be no good built-in functions to subtract Fmed from every pixel, so I had to build one.
+        Fsigma = vectorized_window_Fsig(thisdata[:, :].astype(float), Wdt, padmode="constant")
+
+        # Get coordinates identifying hot pixels by seeing where the difference from the median is out of range of Ns * Fsigma 
+        hoti, hotj = np.ma.where( (Fdif > Ns*Fsigma) | (Fdif < -1.*Ns*Fsigma) )
+    
+        coord = np.array(list(zip(hoti, hotj)))
+
+        # Fix hot pixels by setting to the median value of the small area. 
+        if len(coord)>0:
+            no_hotp[f, hoti, hotj] = Fmed[hoti, hotj]
+
+    return no_hotp
+
+
+def vectorized_window_Fsig(data, Wdt, padmode):
+    """
+    As part of remove_hot_pixels, the code needs to perform the following calculation at every pixel in the original image:
+
+    sqrt( sum((M-Fmed)^2) / ((2*Wdt+1)^2))
+
+    Where M is an array defined by a sliding (2*Wdt+1)x(2*Wdt+1) window, Fmed is the median value within that window, 
+    and Wdt is the radius of the window not including the center pixel. Believe it or not, it's not easy to do that with built-in 
+    functions, which all seem to reduce the size of your data when using the sliding window. This function lets us do the 
+    calculation at every pixel without reducing the size of the data in a vectorized way, avoiding three nested for loops.
+
+    Parameters
+    ----------
+    data : array (2D)
+           Detector image for one integration
+    Wdt : int
+         1/2 the window width, i.e. the "radius". Window side length will be 2*Wdt + 1.
+    padmode : string
+              Values must be generated for regions outside the edge. This mode gets passed to np.pad.
+
+    Returns
+    ----------
+    Fsig : array
+           The calculation sqrt( sum((M-Fmed)^2) / ((2*Wdt+1)^2)) at every pixel. 
+    """
+    # ONLY DEFINED FOR 2D
+    # Find the proper size of a:
+    n = data.shape[0]  # rows
+    m = data.shape[1]  # columns
+
+    window_edge = 2*Wdt + 1
+    # print(f"Sliding window dimensions are [{window_edge_size}, {window_edge_size}]")
+
+    # Pad edges with 0's, to handle edge cases.
+    data_pad = np.pad(data, pad_width=Wdt, mode=padmode, constant_values=np.nan)
+
+    # Get the sliding window shape
+    # Note that the array 'a' is trimmed to be (n-2, m-2) because sliding_window_view can't handle edges.
+    # Since we padded it we are golden
+    window = sliding_window_view(data_pad, (window_edge, window_edge)) 
+    # print(f"Sliding window dimensions are {window.shape}")
+
+    # Operating on data, calculate the median values in a window_edge x window_edge box and make sure they are the same shape as the trimmed array.
+    # axes 2,3 is hard coded because this only works for 2D
+    window_medians = np.nanmedian(window, axis=(2,3)).reshape((window.shape[0], window.shape[1], 1, 1)) 
+
+    # Subtract the medians from the views
+    subtracted_med = np.subtract(window, window_medians)
+    # print(f"Dimensions of subtracted_med are {subtracted_med.shape}")
+    
+    # get sum of squares
+    sumsq = np.nansum(subtracted_med**2, axis=(2,3))    
+    # print(f"Dimensions of sumsq are {sumsq.shape}")
+
+    # Get Fsig
+    Fsig = np.sqrt(sumsq / (window_edge**2))
+    # print(f"Dimensions of array are {a.shape[0]}x{a.shape[1]}")
+    # print(f"Dimensions of Fsig are {Fsig.shape[0]}x{Fsig.shape[1]}")
+
+    return Fsig
+
+
+# Fitting plots because they don't work in echelle_Graphics because of circular import
+
+def plot_line_fit(data_wavelengths, data_vals, model_fit, fit_params_for_printing, data_unc=None, H_a=0, H_b=0, D_a=0, D_b=0, t="Fit", unit="DN", show_integration_regions=False, logview=False):
+    """
+    Plots the fit defined by data_vals to the data, data_wavelengths and data_vals.
+
+    Parameters
+    ----------
+    data_wavelengths : array
+                       Wavelengths in nm for the recorded data
+    data_vals : array
+                Values on the detector at a given wavelength, either in DN or kR after conversion.
+    model_fit : array
+                Fit of the LSF to the H and D emissions
+    fit_params_for_printing : dictionary
+                 A custom dictionary object for easily accessing the parameter fits by name.
+                 Keys: area, area_d, lambdac, lambdac_D, M, B.
+    H_a, H_b, D_a, D_b : ints
+                         indices of data_wavelengths over which the line area was integrated.
+                         Used here to call fill_betweenx in the event we want to show it on the plot.
+    t : string
+        title to use for the plot.
+    unit : string
+           description of the unit to write on the y-axis label. Typically "DN" or "kR" with a /s/nm possibly appended.
+         
+    """
+
+    fig = plt.figure(figsize=(8,6))
+    mygrid = gs.GridSpec(4, 1, figure=fig, hspace=0.1)
+    mainax = plt.subplot(mygrid.new_subplotspec((0, 0), colspan=1, rowspan=3)) 
+    residax = plt.subplot(mygrid.new_subplotspec((3, 0), colspan=1, rowspan=1), sharex=mainax) 
+
+    mainax.tick_params(labelbottom=False)
+    residax.tick_params(labelbottom=True)
+    mainax.set_title(t)
+        
+    # Plot the data and fit and a guideline for the central wavelength
+    mainax.errorbar(data_wavelengths, data_vals, yerr=data_unc, label="data", linewidth=1, zorder=3, alpha=0.7)
+    mainax.plot(data_wavelengths, model_fit, label="fit", linewidth=2, zorder=2)
+    mainax.axvline(fit_params_for_printing['lambdac'], color="gray", zorder=1, linewidth=0.5, )
+
+    if show_integration_regions:
+        mainax.fill_betweenx([0, np.max(data_vals)], data_wavelengths[H_a], x2=data_wavelengths[H_b], color="xkcd:salmon", alpha=0.3, zorder=1)
+        mainax.fill_betweenx([0, np.max(data_vals)], data_wavelengths[D_a], x2=data_wavelengths[D_b], color="xkcd:slate blue", alpha=0.3, zorder=1)
+
+    # get index of lambda for D so we can find the value there
+    if fit_params_for_printing["lambdac_D"] is not np.nan:
+        D_i = find_nearest(data_wavelengths, fit_params_for_printing['lambdac_D'])[0]
+        mainax.axvline(fit_params_for_printing['lambdac_D'], color="gray", linewidth=0.5, zorder=1)
+    
+    # Print text
+    linestart = 0.7
+    linedy = 0.05
+    printme = [r"H $\lambda_c$: "+f"{round(fit_params_for_printing['lambdac'], 3)}", 
+               r"D $\lambda_c$: "+f"{round(fit_params_for_printing['lambdac_D'], 3)}",
+              ]
+
+    # Plot background fit
+    thebackground = background(data_wavelengths, fit_params_for_printing['M'], fit_params_for_printing['lambdac'], fit_params_for_printing['B'])
+    mainax.plot(data_wavelengths, thebackground, label="background", linewidth=2, zorder=2)
+    
+    # Now subtract the background entirely from the fit and then integrate to see the total brightness
+    if "kR" in unit:
+        # background_subtracted = data_vals - thebackground
+        # Htot, Dtot = line_brightness(data_wavelengths, background_subtracted, [H_a, H_b], [D_a, D_b])
+        print(fit_params_for_printing['area'])
+        printme.append(f"H brightness: {fit_params_for_printing['area']}")
+        printme.append(f"D brightness: {fit_params_for_printing['area_D']}")
+
+    j = 0
+    for i in range(0, len(printme)):
+        if (i == 3) & (fit_params_for_printing["lambdac_D"] is np.nan):
+            continue
+        else: 
+            mainax.text(0.55, linestart-j*linedy, printme[i], transform=mainax.transAxes)
+            j += 1
+
+    # ax.set_yscale("log")
+    mainax.set_ylabel(f"Brightness ({unit})")
+    if logview:
+        mainax.set_yscale("log")
+    mainax.legend()
+    mainax.set_xlim(min(data_wavelengths)-0.02, max(data_wavelengths)+0.02)
+
+    # Residual axis
+    sign = np.sign(model_fit-data_vals)
+    residual = sign * (model_fit - data_vals)**2
+    residax.plot(data_wavelengths, residual, linewidth=1)
+    residax.set_ylabel(f"Residuals\n (sgn((fit-data)^2))")
+    residax.set_xlabel("Wavelength (nm)")
+    
+    plt.show()
+
+    pass

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -17,7 +17,7 @@ import subprocess
 from numpy.lib.stride_tricks import sliding_window_view
 from maven_iuvs.binning import get_bin_edges, get_binning_scheme, get_pix_range
 from maven_iuvs.constants import D_offset
-# from maven_iuvs.graphics.echelle_graphics import plot_line_fit
+import maven_iuvs.graphics.echelle_graphics as echgr # Avoids circular import problem
 from maven_iuvs.instrument import ech_LSF_unit, convert_spectrum_DN_to_photoevents, \
                                    get_wavelengths, \
                                    ech_Lya_slit_start, ech_Lya_slit_end, \
@@ -1153,13 +1153,12 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
 
         # Plot in kR/sec/nm
         # plot_line_fit(wavelengths, spec_kR_pernm, I_fit_kR_pernm, fit_params_for_printing, data_unc=unc_kr_per_nm, t=titletext, unit=unittext_kR, 
-        #               H_a=H_i[0], H_b=H_i[1], D_a=D_i[0], D_b=D_i[1] )
+        #               H_a=H_i[0], H_b=H_i[1], D_a=D_i[0], D_b=D_i[1], plot_bg=bg_fit)
         
-        # Also plot with the BU background ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        # plot_line_fit_BUbg(wavelengths, spec_per_kR, I_fit_kR_BUbg, fit_params_for_printing_BUbg, IDL_style_background_converted, data_unc=unc_kr_idl, 
-        #                    t=f"Fit with the BU background, int={i}", unit="kR", H_a=H_i[0], H_b=H_i[1], D_a=D_i[0], D_b=D_i[1])
-        plot_line_fit_comparison(wavelengths, spec_kR_pernm, spec_per_kR, I_fit_kR_pernm, I_fit_kR_BUbg, fit_params_for_printing, 
-                                 fit_params_for_printing_BUbg, IDL_style_background_converted, unit=["kR/nm", "kR"], data_unc_new=unc_kr_per_nm, data_unc_BU=unc_kr_idl, suptitle=titletext)
+        # Plot a comparison of the two methods ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        echgr.plot_line_fit_comparison(wavelengths, spec_kR_pernm, spec_per_kR, I_fit_kR_pernm, I_fit_kR_BUbg, fit_params_for_printing, 
+                                 fit_params_for_printing_BUbg, IDL_style_background_converted, background_array,
+                                 unit=["kR/nm", "kR"], data_unc_new=unc_kr_per_nm, data_unc_BU=unc_kr_idl, suptitle=titletext)
         
         # Background comparison
         # ============================================================================================
@@ -2163,219 +2162,3 @@ def vectorized_window_Fsig(data, Wdt, padmode):
 
     return Fsig
 
-
-# Fitting plots because they don't work in echelle_Graphics because of circular import
-
-def plot_line_fit(data_wavelengths, data_vals, model_fit, fit_params_for_printing, data_unc=None, H_a=0, H_b=0, D_a=0, D_b=0, t="Fit", unit="DN", show_integration_regions=False, logview=False, plot_bg=True):
-    """
-    Plots the fit defined by data_vals to the data, data_wavelengths and data_vals.
-
-    Parameters
-    ----------
-    data_wavelengths : array
-                       Wavelengths in nm for the recorded data
-    data_vals : array
-                Values on the detector at a given wavelength, either in DN or kR after conversion.
-    model_fit : array
-                Fit of the LSF to the H and D emissions
-    fit_params_for_printing : dictionary
-                 A custom dictionary object for easily accessing the parameter fits by name.
-                 Keys: area, area_d, lambdac, lambdac_D, M, B.
-    H_a, H_b, D_a, D_b : ints
-                         indices of data_wavelengths over which the line area was integrated.
-                         Used here to call fill_betweenx in the event we want to show it on the plot.
-    t : string
-        title to use for the plot.
-    unit : string
-           description of the unit to write on the y-axis label. Typically "DN" or "kR" with a /s/nm possibly appended.
-         
-    """
-
-    mpl.rcParams["font.sans-serif"] = "Louis George Caf?"
-    mpl.rcParams['font.size'] = 18
-    mpl.rcParams['legend.fontsize'] = 16
-    mpl.rcParams['xtick.labelsize'] = 16
-    mpl.rcParams['ytick.labelsize'] = 16
-    mpl.rcParams['axes.labelsize'] = 18
-    mpl.rcParams['axes.titlesize'] = 22
-
-    fig = plt.figure(figsize=(8,6))
-    mygrid = gs.GridSpec(4, 1, figure=fig, hspace=0.1)
-    mainax = plt.subplot(mygrid.new_subplotspec((0, 0), colspan=1, rowspan=3)) 
-    residax = plt.subplot(mygrid.new_subplotspec((3, 0), colspan=1, rowspan=1), sharex=mainax) 
-
-    mainax.tick_params(labelbottom=False)
-    residax.tick_params(labelbottom=True)
-    mainax.set_title(t)
-
-    # Plot background fit
-    if plot_bg:
-        thebackground = background(data_wavelengths, fit_params_for_printing['M'], fit_params_for_printing['lambdac'], fit_params_for_printing['B'])
-        mainax.plot(data_wavelengths, thebackground, label="background", linewidth=2, zorder=2)
-        
-    # Plot the data and fit and a guideline for the central wavelength
-    mainax.errorbar(data_wavelengths, data_vals, yerr=data_unc, label="data", linewidth=1, zorder=3, alpha=0.7)
-    mainax.plot(data_wavelengths, model_fit, label="model", linewidth=2, zorder=2)
-    mainax.axvline(fit_params_for_printing['lambdac'], color="gray", zorder=1, linewidth=0.5, )
-
-    if show_integration_regions:
-        mainax.fill_betweenx([0, np.max(data_vals)], data_wavelengths[H_a], x2=data_wavelengths[H_b], color="xkcd:salmon", alpha=0.3, zorder=1)
-        mainax.fill_betweenx([0, np.max(data_vals)], data_wavelengths[D_a], x2=data_wavelengths[D_b], color="xkcd:slate blue", alpha=0.3, zorder=1)
-
-    # get index of lambda for D so we can find the value there
-    if fit_params_for_printing["lambdac_D"] is not np.nan:
-        D_i = find_nearest(data_wavelengths, fit_params_for_printing['lambdac_D'])[0]
-        mainax.axvline(fit_params_for_printing['lambdac_D'], color="gray", linewidth=0.5, zorder=1)
-    
-    # Print text
-    printme = [#r"H $\lambda_c$: "+f"{round(fit_params_for_printing['lambdac'], 3)}", 
-               #r"D $\lambda_c$: "+f"{round(fit_params_for_printing['lambdac_D'], 3)}",
-              ]
-    
-    # Now subtract the background entirely from the fit and then integrate to see the total brightness
-    if "kR" in unit:
-        # background_subtracted = data_vals - thebackground
-        # Htot, Dtot = line_brightness(data_wavelengths, background_subtracted, [H_a, H_b], [D_a, D_b])
-        printme.append(f"H: {fit_params_for_printing['area']} ± {fit_params_for_printing['uncert_H']} kR")
-        printme.append(f"D: {fit_params_for_printing['area_D']} ± {fit_params_for_printing['uncert_D']} kR")
-        textx = [0.38, 0.28]
-        texty = [0.5, 0.17]
-        talign = ["left", "right"]
-
-    for i in range(0, len(printme)):
-        mainax.text(textx[i], texty[i], printme[i], transform=mainax.transAxes, ha=talign[i])
-
-    # ax.set_yscale("log")
-    mainax.set_ylabel(f"Brightness ({unit})")
-    if logview:
-        mainax.set_yscale("log")
-    mainax.legend()
-    mainax.set_xlim(min(data_wavelengths)-0.02, max(data_wavelengths)+0.02)
-
-    # Residual axis
-    sign = np.sign(model_fit-data_vals)
-    residual = sign * (data_vals - model_fit)**2
-    residax.plot(data_wavelengths, residual, linewidth=1)
-    residax.set_ylabel(f"Residuals\n (sgn((data-model)^2))")
-    residax.set_xlabel("Wavelength (nm)")
-    
-    plt.show()
-
-    pass
-
-
-def plot_line_fit_comparison(data_wavelengths, data_vals_new, data_vals_BU, model_fit_new, model_fit_BU, fit_params_new, fit_params_BU, BUbackground, 
-                             data_unc_new=None, data_unc_BU=None, H_a=0, H_b=0, D_a=0, D_b=0, titles=["Python fit, linear background", "Python fit, Mayyasi+2023 background"], 
-                             suptitle=None, unit=None, logview=False, plot_bg=True):
-    """
-    Plots the fit defined by data_vals to the data, data_wavelengths and data_vals.
-
-    Parameters
-    ----------
-    data_wavelengths : array
-                       Wavelengths in nm for the recorded data
-    data_vals : array
-                Values on the detector at a given wavelength, either in DN or kR after conversion.
-    model_fit : array
-                Fit of the LSF to the H and D emissions
-    fit_params_for_printing : dictionary
-                 A custom dictionary object for easily accessing the parameter fits by name.
-                 Keys: area, area_d, lambdac, lambdac_D, M, B.
-    H_a, H_b, D_a, D_b : ints
-                         indices of data_wavelengths over which the line area was integrated.
-                         Used here to call fill_betweenx in the event we want to show it on the plot.
-    t : string
-        title to use for the plot.
-    unit : string
-           description of the unit to write on the y-axis label. Typically "DN" or "kR" with a /s/nm possibly appended.
-         
-    """
-
-    mpl.rcParams["font.sans-serif"] = "Louis George Caf?"
-    mpl.rcParams['font.size'] = 18
-    mpl.rcParams['legend.fontsize'] = 16
-    mpl.rcParams['xtick.labelsize'] = 16
-    mpl.rcParams['ytick.labelsize'] = 16
-    mpl.rcParams['axes.labelsize'] = 18
-    mpl.rcParams['axes.titlesize'] = 22
-
-    fig = plt.figure(figsize=(16,6))
-    mygrid = gs.GridSpec(4, 2, figure=fig, hspace=0.1, wspace=0.1)
-    mainax_new = plt.subplot(mygrid.new_subplotspec((0, 0), colspan=1, rowspan=3)) 
-    residax_new = plt.subplot(mygrid.new_subplotspec((3, 0), colspan=1, rowspan=1), sharex=mainax_new) 
-    mainax_BU = plt.subplot(mygrid.new_subplotspec((0, 1), colspan=1, rowspan=3)) 
-    residax_BU = plt.subplot(mygrid.new_subplotspec((3, 1), colspan=1, rowspan=1), sharex=mainax_BU) 
-
-    for (t,  u, ma) in zip(titles, unit, [mainax_new, mainax_BU]):
-        ma.tick_params(labelbottom=False)
-        ma.set_title(t)
-        ma.set_xlim(min(data_wavelengths)-0.02, max(data_wavelengths)+0.02)
-        ma.set_ylabel(f"Brightness ({u})")
-
-    for ra in [residax_new, residax_BU]:
-        ra.tick_params(labelbottom=True)
-        ra.set_xlabel("Wavelength (nm)")
-
-    plt.suptitle(suptitle, y=1.05)
-    
-    # Plot background fit
-    if plot_bg:
-        py_lin_bg = background(data_wavelengths, fit_params_new['M'], fit_params_new['lambdac'], fit_params_new['B'])
-        mainax_new.plot(data_wavelengths, py_lin_bg, label="background", linewidth=2, zorder=2)
-        mainax_BU.plot(data_wavelengths, BUbackground, label="background", linewidth=2, zorder=2)
-        
-    # Plot the data and fit and a guideline for the central wavelength
-    mainax_new.errorbar(data_wavelengths, data_vals_new, yerr=data_unc_new, label="data", linewidth=1, zorder=3, alpha=0.7)
-    mainax_new.plot(data_wavelengths, model_fit_new, label="model (new)", linewidth=2, zorder=2)
-    mainax_new.axvline(fit_params_new['lambdac'], color="gray", zorder=1, linewidth=0.5, )
-
-    mainax_BU.errorbar(data_wavelengths, data_vals_BU, yerr=data_unc_BU, label="data", linewidth=1, zorder=3, alpha=0.7)
-    mainax_BU.plot(data_wavelengths, model_fit_BU, label="model (BU)", linewidth=2, zorder=2)
-    mainax_BU.axvline(fit_params_BU['lambdac'], color="gray", zorder=1, linewidth=0.5, )
-
-    # get index of lambda for D so we can find the value there
-    if fit_params_new["lambdac_D"] is not np.nan:
-        D_i = find_nearest(data_wavelengths, fit_params_new['lambdac_D'])[0]
-        mainax_new.axvline(fit_params_new['lambdac_D'], color="gray", linewidth=0.5, zorder=1)
-
-    if fit_params_BU["lambdac_D"] is not np.nan:
-        D_i = find_nearest(data_wavelengths, fit_params_BU['lambdac_D'])[0]
-        mainax_BU.axvline(fit_params_BU['lambdac_D'], color="gray", linewidth=0.5, zorder=1)
-    
-    # Print text
-    printme_new = []
-    printme_BU = []
-    
-    # Now subtract the background entirely from the fit and then integrate to see the total brightness
-    printme_new.append(f"H: {fit_params_new['area']} kR")
-    printme_new.append(f"D: {fit_params_new['area_D']} kR")
-    printme_BU.append(f"H: {fit_params_BU['peakH']} kR")
-    printme_BU.append(f"D: {fit_params_BU['peakD']} kR")
-    textx = [0.38, 0.28]
-    texty = [0.5, 0.17]
-    talign = ["left", "right"]
-
-    for i in range(0, len(printme_new)):
-        mainax_new.text(textx[i], texty[i], printme_new[i], transform=mainax_new.transAxes, ha=talign[i])
-        mainax_BU.text(textx[i], texty[i], printme_BU[i], transform=mainax_BU.transAxes, ha=talign[i])
-
-    # ax.set_yscale("log")
-    residax_new.set_ylabel(f"Residuals\n (sgn((data-model)^2))")
-    if logview:
-        mainax_new.set_yscale("log")
-        mainax_BU.set_yscale("log")
-    mainax_new.legend()
-    mainax_BU.legend()
-
-    # Residual axis
-    sign_new = np.sign(model_fit_new - data_vals_new)
-    residual_new = sign_new * (data_vals_new - model_fit_new)**2
-    residax_new.plot(data_wavelengths, residual_new, linewidth=1)
-
-    sign_BU = np.sign(model_fit_BU - data_vals_BU)
-    residual_BU = sign_BU * (data_vals_BU - model_fit_BU)**2
-    residax_BU.plot(data_wavelengths, residual_BU, linewidth=1)
-    
-    plt.show()
-
-    pass

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -1496,6 +1496,8 @@ def badness_of_fit(params, wavelength_data, DN_data, binedges, CLSF, uncertainty
 
     Parameters
     ----------
+    params : array
+             Fit parameters to be evaluated for badness
     wavelength_data : array
              wavelength that will be fit; nm 
     DN_data : array

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -20,7 +20,7 @@ from maven_iuvs.constants import D_offset
 # from maven_iuvs.graphics.echelle_graphics import plot_line_fit
 from maven_iuvs.instrument import ech_LSF_unit, convert_spectrum_DN_to_photons, \
                                    get_ech_slit_indices, ech_Lya_slit_start, ech_Lya_slit_end, \
-                                   mcp_dn_to_volt, mcp_volt_to_gain
+                                   ran_DN_uncertainty
 from maven_iuvs.miscellaneous import get_n_int, locate_missing_frames, \
     iuvs_orbno_from_fname, iuvs_filename_to_datetime, iuvs_segment_from_fname, \
     uniqueID_RE, find_nearest, fn_RE, orbit_folder
@@ -1871,24 +1871,6 @@ def add_in_quadrature(uncertainties, light_fits, integration=0):
 
     return total_uncert
 
-
-def ran_DN_uncertainty(light_fits, dark_subtracted_and_cleaned_data):
-    """
-    Figure out the random uncertainty in DN.
-
-    # Let's start by just wholesale adapting the uncertainty calculation from Matteo in the IDL pipeline and see what it looks like.
-    # In progress
-    """
-    volt = mcp_dn_to_volt(light_fits['Engineering'].data['MCP_GAIN'][0])   # I think it's wrong to use this. IDL is acquiring the voltage. mcp_volt_to_gain(, channel="FUV")
-    n_bins = light_fits['primary'].header['spe_size'] * light_fits['primary'].header['spa_size'] # in a square bin of spatial x spectral. works out to 22 for recent dat
-    sigma_background = 4313 * math.sqrt(light_fits["Primary"].header["INT_TIME"]/60) * math.sqrt(n_bins/480.)/(2**((850-volt)/50.)) # WHERE the heck did I get this??
-    fit_function = 40 / (2**((700-volt)/50))
-    
-    # This is the correct shape, not sure if it's reasonable values though:
-    ran_DN = np.sqrt(dark_subtracted_and_cleaned_data * fit_function + sigma_background**2) # TODO: check if it's okay to do this on the cleaned data. Probably not
-    ran_DN[np.where(np.isnan(ran_DN))] = 0 # TODO: this is not acceptable lol
-
-    return ran_DN
 
 
 def get_wavelengths(light_fits):

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -28,7 +28,6 @@ from maven_iuvs.geometry import has_geometry_pvec
 from maven_iuvs.search import get_latest_files, find_files
 from maven_iuvs.integration import get_avg_pixel_count_rate
 from statistics import median_high
-from maven_iuvs.instrument import ech_Lya_slit_start, ech_Lya_slit_end
 
 from statsmodels.tools.numdiff import approx_hess1, approx_hess2, approx_hess3
 from numpy.linalg import inv

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -1244,8 +1244,31 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
           
 
 def do_conversion(light_fits, model_I, spec, unc, background_array, model_conversion, calibration="new"):
+def DN_to_physical_units(light_fits, model_I, spec, unc, background_array, model_conversion):
     """
-    Convert DN to physical units, kR / nm
+    Converts DN to physical units of kR / nm.
+
+    Parameters
+    ----------
+    light_fits : astropy.io.fits instance
+                File with light observation
+    model_I : 1D array
+              DN per bin; outcome of fitting the emission lines.
+    spec : 1D array
+           Spectrum in DN obtained after coadding the detector image across the slit in the spatial direction
+    unc : 1D array
+          DN uncertainty of spec
+    background_array : 1D array
+                       Fitted background
+    model_conversion : Float
+                       A conversion factor for translating the fit and spectrum to physical units; 
+                       depends on the data within the FITS file itself.
+    Returns
+    ----------
+    I_fit_phys_units, spec_phys_units, 
+    background_phys_units, unc_phys_units : 1D arrays
+                                            The input arguments after conversion.
+        
     """
     I_fit_phys_units = convert_spectrum_DN_to_photons(light_fits, model_I) * model_conversion
     spec_phys_units = convert_spectrum_DN_to_photons(light_fits, spec) * model_conversion

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -1011,7 +1011,7 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
 
     # Conversion factors
     # ============================================================================================
-    conv_to_kR_per_nm, conv_to_kR_with_LSFunit, conv_to_kR = conversion_factors(t_int, binwidth_nm, calibration=calibration)
+    conv_to_kR_per_nm, conv_to_kR_with_LSFunit, conv_to_kR = get_conversion_factors(t_int, binwidth_nm, calibration=calibration)
 
     # Uncertainty on the data 
     # ============================================================================================
@@ -1097,8 +1097,8 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
         # Using the BU bg ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
         # Convert to physical units
-        I_fit_kR_BUbg, spec_per_kR, IDL_style_background_converted, unc_kr_idl = get_conversion_factors(light_fits, I_fit_BUbg, spec, unc, 
-                                                                                               IDL_style_background, conv_to_kR_with_LSFunit, calibration=calibration)
+        I_fit_kR_BUbg, spec_per_kR, IDL_style_background_converted, unc_kr_idl = DN_to_physical_units(light_fits, I_fit_BUbg, spec, unc, 
+                                                                                               IDL_style_background, conv_to_kR_with_LSFunit)
         
         # Subtract the background - we have to do this becuase in this method we need the peak vlaue, and it's larger by (background)
         # if we don't subtract background.
@@ -1116,8 +1116,7 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
         # Line integrated brightness method
         # ---------------------------------------------------------------------------------------------------
         # Convert to physical unitslight_fits, model_I, spec, unc, background_array, model_conversion
-        I_fit_kR_pernm, spec_kR_pernm, background_array, unc_kr_per_nm = get_conversion_factors(light_fits, I_fit, spec, unc, bg_fit, conv_to_kR_per_nm,
-                                                                                       calibration=calibration)
+        I_fit_kR_pernm, spec_kR_pernm, background_array, unc_kr_per_nm = DN_to_physical_units(light_fits, I_fit, spec, unc, bg_fit, conv_to_kR_per_nm)
         
         # In order to plot the background, we have to fit the background again once it's in the right units to 
         # get the converted slope and intercept.

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -301,6 +301,16 @@ def coadd_lights(light_fits, dark_fits, return_bad_inds=True, clean_data=True, m
         return coadded_lights, total_good_frames
 
 
+def median_light_frame(light_fits, dark_fits):
+    """
+    Obtains a median light frame, which can be useful for displaying the observations without cosmic rays, etc.
+    """
+    dark_subtracted, nan_light_inds, bad_light_inds, nan_dark_inds = subtract_darks(light_fits, dark_fits)
+    medframe = np.nanmedian(dark_subtracted, axis=0)
+
+    return medframe
+
+
 def subtract_darks(light_fits, dark_fits):
     """
     Given matching light and dark fits, subtracts off the darks from lights

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -1,10 +1,12 @@
 import datetime
 import numpy as np
+import scipy as sp
 from astropy.io import fits
 import textwrap
 import os 
 import copy
 import skimage as ski
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gs
 import math
@@ -1740,6 +1742,14 @@ def plot_line_fit(data_wavelengths, data_vals, model_fit, fit_params_for_printin
          
     """
 
+    mpl.rcParams["font.sans-serif"] = "Louis George Caf?"
+    mpl.rcParams['font.size'] = 18
+    mpl.rcParams['legend.fontsize'] = 16
+    mpl.rcParams['xtick.labelsize'] = 16
+    mpl.rcParams['ytick.labelsize'] = 16
+    mpl.rcParams['axes.labelsize'] = 18
+    mpl.rcParams['axes.titlesize'] = 22
+
     fig = plt.figure(figsize=(8,6))
     mygrid = gs.GridSpec(4, 1, figure=fig, hspace=0.1)
     mainax = plt.subplot(mygrid.new_subplotspec((0, 0), colspan=1, rowspan=3)) 
@@ -1764,10 +1774,8 @@ def plot_line_fit(data_wavelengths, data_vals, model_fit, fit_params_for_printin
         mainax.axvline(fit_params_for_printing['lambdac_D'], color="gray", linewidth=0.5, zorder=1)
     
     # Print text
-    linestart = 0.7
-    linedy = 0.05
-    printme = [r"H $\lambda_c$: "+f"{round(fit_params_for_printing['lambdac'], 3)}", 
-               r"D $\lambda_c$: "+f"{round(fit_params_for_printing['lambdac_D'], 3)}",
+    printme = [#r"H $\lambda_c$: "+f"{round(fit_params_for_printing['lambdac'], 3)}", 
+               #r"D $\lambda_c$: "+f"{round(fit_params_for_printing['lambdac_D'], 3)}",
               ]
 
     # Plot background fit
@@ -1778,17 +1786,14 @@ def plot_line_fit(data_wavelengths, data_vals, model_fit, fit_params_for_printin
     if "kR" in unit:
         # background_subtracted = data_vals - thebackground
         # Htot, Dtot = line_brightness(data_wavelengths, background_subtracted, [H_a, H_b], [D_a, D_b])
-        print(fit_params_for_printing['area'])
-        printme.append(f"H brightness: {fit_params_for_printing['area']}")
-        printme.append(f"D brightness: {fit_params_for_printing['area_D']}")
+        printme.append(f"H: {fit_params_for_printing['area']} kR")
+        printme.append(f"D: {fit_params_for_printing['area_D']} kR")
+        textx = [0.38, 0.28]
+        texty = [0.5, 0.17]
+        talign = ["left", "right"]
 
-    j = 0
     for i in range(0, len(printme)):
-        if (i == 3) & (fit_params_for_printing["lambdac_D"] is np.nan):
-            continue
-        else: 
-            mainax.text(0.55, linestart-j*linedy, printme[i], transform=mainax.transAxes)
-            j += 1
+        mainax.text(textx[i], texty[i], printme[i], transform=mainax.transAxes, ha=talign[i])
 
     # ax.set_yscale("log")
     mainax.set_ylabel(f"Brightness ({unit})")

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -1377,17 +1377,17 @@ def get_conversion_factors(t_int, binwidth_nm, calibration="new"):
     """
     Identify and return the appropriate conversion factors for the data.
     """
-    Aeff =  32.327455  # Acquired by testing on one file, 16910 outdisk. TODO: Check if this needs to change with each file. 
+    Aeff =  32.327455  # Acquired by testing on one file in the IDL pipeline, 16910 outdisk. 
+                       # Does not seem to change with different files.
 
     if calibration=="new":
         conv_to_kR_with_LSFunit = ech_LSF_unit / (t_int)
-    elif calibration=="old": # Currently set to be the same because trying to implement what they actually did in the old versoin
-                             # causes errors...
-        # Ph_pers_perkR = 29.8
-        # Adj_Factor = 100/88  
-        # conv_to_kR_brightness = Adj_Factor / (t_int * Ph_pers_perkR) # There's some extra factors in the old cal...
-        # conv_to_kR_spectrum = 1 / (t_int)
-        conv_to_kR_with_LSFunit = ech_LSF_unit / (t_int)
+    elif calibration=="old":
+        Ph_pers_perkR = 29.8 # There's some extra factors in the old cal...
+        Adj_Factor = 1# 100/88  # This factor is used in IDL, but it accounts for the fact that the method used is not flux-conservative.
+                                # We are using a conservative fit method so we don't need it, but I'm placing it here just in case
+                                # we need to refer to it in future / in case I did something wrong.
+        conv_to_kR_with_LSFunit = Adj_Factor / (t_int * Ph_pers_perkR)
 
     conv_to_kR_per_nm = 1 / (t_int * binwidth_nm * Aeff)
     conv_to_kR = 1 / (t_int * Aeff)

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -1308,7 +1308,8 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
             # Above slit
             empty_spec_above_slit = np.sum(data[i, new_aprow1:new_aprow2+1 :], axis=0) # similar to IDL line: off_slit = total(img[*,new_aprow1:new_aprow2,*], 2)
             # Dark frame
-            empty_spec_dark_frame = np.sum(dark_fits['Primary'].data[abs(np.sign(i)), si1:si2, :], axis=0) # abs(np.sign()) returns 0 if i = 0, 1 else.
+            empty_spec_dark_frame = np.sum(dark_fits['Primary'].data[abs(np.sign(i)), si1:si2+1, :], axis=0) # abs(np.sign()) returns 0 if i = 0, 1 else.
+            # +1 because of the way python does indices.
 
             # Fit background, subtract, and plot
             for (fake_spec, lbl, t) in zip([empty_spec_above_slit, empty_spec_dark_frame],
@@ -1925,11 +1926,11 @@ def get_spectrum(data, light_fits, average=False, coadded=False, integration=0):
     si1, si2 = get_ech_slit_indices(light_fits)
 
     if coadded:
-        spectrum = np.sum(data[si1:si2, :], axis=0)
+        spectrum = np.sum(data[si1:si2+1, :], axis=0) # +1 because of the way python does indices.
     else:
         # Sum up the spectra over the range in which Ly alpha is visible on the slit (not outside it)
         # This spectrum is thus in DN
-        spectrum = np.sum(data[integration, si1:si2, :], axis=0)
+        spectrum = np.sum(data[integration, si1:si2+1, :], axis=0)
         
     if average:
         spectrum = spectrum / (si2 - si1)
@@ -1962,8 +1963,8 @@ def add_in_quadrature(uncertainties, light_fits, integration=0):
     # Collect pixel range which we need to find the slit start and end 
     si1, si2 = get_ech_slit_indices(light_fits)
 
-    total_uncert = np.sqrt( np.sum( (uncertainties[integration, si1:si2, :])**2, axis=0) )
-
+    total_uncert = np.sqrt( np.sum( (uncertainties[integration, si1:si2+1, :])**2, axis=0) )
+    # +1 because of the way python does indices.
     return total_uncert
 
 
@@ -2053,7 +2054,7 @@ def get_lya_mask(datacube, light_fits):
     mask = np.zeros_like(datacube[0, :, :]) # only needs to be 2D.
     si1, si2 = get_ech_slit_indices(light_fits) # slit
     wi = np.asarray(np.where(np.logical_and(get_wavelengths(light_fits)>=121.53, get_wavelengths(light_fits)<=121.58)))[0]
-    mask[si1:si2+1, wi] = 1 
+    mask[si1:si2+1, wi] = 1  # +1 because of the way python does indices.
     return mask
 
 

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -1293,7 +1293,7 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
         center_idx = 4
         this_dict = binning_df.loc[(binning_df['Nspa'] == get_binning_scheme(light_fits)["nspa"]) & (binning_df['Nspe'] == get_binning_scheme(light_fits)["nspe"])]
         yMRH = 485 # the location of the row most-accurately representing the MRH altitudes across the aperture center (to be used by all emissions)
-        yMRH = math.floor((yMRH-this_dict['ycH'].values[0])/this_dict['NbinsY'].values[0]) #  to get an integer value liek IDL does.
+        yMRH = math.floor((yMRH-this_dict['ycH'].values[0])/this_dict['NbinsY'].values[0]) #  to get an integer value like IDL does.
 
         thedict = {
             "BRIGHT_H_kR": H_brightnesses, #  H brightness (BkR_H) in kR

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -15,11 +15,11 @@ import re
 import pandas as pd
 import subprocess
 from numpy.lib.stride_tricks import sliding_window_view
-from maven_iuvs.binning import get_bin_edges, get_binning_scheme
+from maven_iuvs.binning import get_bin_edges, get_binning_scheme, get_pix_range
 from maven_iuvs.constants import D_offset
 # from maven_iuvs.graphics.echelle_graphics import plot_line_fit
 from maven_iuvs.instrument import ech_LSF_unit, convert_spectrum_DN_to_photons, \
-                                   get_ech_slit_indices, get_wavelengths, \
+                                   get_wavelengths, \
                                    ech_Lya_slit_start, ech_Lya_slit_end, \
                                    ran_DN_uncertainty
 from maven_iuvs.miscellaneous import get_n_int, locate_missing_frames, \
@@ -880,6 +880,28 @@ def find_files_with_geometry(file_index):
 
     # print(f'{len(with_geom)} have geometry.\n')
     return with_geom
+
+# Basic echelle mode information ----------------------------------------
+
+def get_ech_slit_indices(light_fits):
+    """
+    Get the indices along the spatial dimension of the detector array that correspond 
+    to the beginning and end of the echelle slit. 
+
+    Parameters 
+    ----------
+    light_fits : astropy.io.fits instance
+                 File with light observation
+
+    Returns 
+    ----------
+    list containing slit_i1, slit_i2, the indices of the start and end of the slit. 
+    """
+    spapixrng = get_pix_range(light_fits, which="spatial")
+    slit_i1 = find_nearest(spapixrng, ech_Lya_slit_start)[0]  # start of slit
+    slit_i2 = find_nearest(spapixrng, ech_Lya_slit_end)[0]  # end of slit
+    return [slit_i1, slit_i2]
+
 
 # L1c processing ===========================================================
 

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -990,8 +990,9 @@ def get_ech_slit_indices(light_fits):
 
 # L1c processing ===========================================================
 
-def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibration="new", solv="Powell", fitpackage="scipy", approach="dynamic", 
-                       livepts=500, clean_data=True, clean_method="new", run_writeout=True, check_background=False, plot_subtract_bg=True, plot_bg_separately=False, remove_rays=True, remove_hotpix=True,
+def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibration="new", solv="Powell", fitpackage="scipy", approach="dynamic", livepts=500, 
+                       clean_data=True, clean_method="new", run_writeout=True, check_background=False, plot_subtract_bg=True, plot_bg_separately=False, 
+                       remove_rays=True, remove_hotpix=True,
                        idl_pipeline_folder="/home/emc/OneDrive-CU/Research/IUVS/IDL_pipeline/"):
     """
     Converts a single l1a echelle observation to l1c. At present, two .csv files containing some 
@@ -1021,6 +1022,8 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
     approach : string
                "static" to use Dynesty's NestedSampler
                "dynamic" to use DynamicNestedSampler
+    livepts : integer
+              number of live points to use within the Dynesty solver
     clean_data : boolean
                  Whether to perform cosmic ray removal and hot pixel adjustment.
     clean_method : string
@@ -1034,6 +1037,15 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
                        minus the background fit there are comparable to zero.
     plot_subtract_bg : boolean
                        if True, subtracts background from model and data before plotting them.
+    plot_bg_separately : boolean
+                         if True, the background will be plotted as a separate line on the fit plots
+    remove_rays : boolean
+                  if True, the remove_cosmic_rays() routine will be run.
+    remove_hotpix : boolean
+                    if True, the remove_hot_pixels() routine will be run.
+    idl_pipeline_folder : string
+                          Local path of the IDL pipeline software, to which certain files will be written out 
+                          to allow for the final l1c product creation via IDL called from subprocess.
 
     Returns
     ----------

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -1131,8 +1131,8 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
     D_brightnesses = np.empty(n_int)
     H_bright_1sig = np.empty(n_int)
     D_bright_1sig = np.empty(n_int)
-    H_brightnesses_peak_method_BUbg = np.empty(n_int) # for BU background
-    D_brightnesses_peak_method_BUbg = np.empty(n_int) # for BU background
+    H_brightnesses_BUbg = np.empty(n_int) # for BU background
+    D_brightnesses_BUbg = np.empty(n_int) # for BU background
     bright_data_ph_per_s = np.ndarray((n_int, get_wavelengths(light_fits).size))
 
     # Wavelengths and binwidths (which typically don't change)
@@ -1370,7 +1370,7 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, calibrat
         print("Finished writing to IDL, I hope")
 
     return H_brightnesses, D_brightnesses,\
-           H_brightnesses_peak_method_BUbg, D_brightnesses_peak_method_BUbg
+           H_brightnesses_BUbg, D_brightnesses_BUbg
 
 
 def get_conversion_factors(t_int, binwidth_nm, calibration="new"):

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -1282,7 +1282,7 @@ def DN_to_physical_units(light_fits, model_I, spec, unc, background_array, model
     return I_fit_phys_units, spec_phys_units, background_phys_units, unc_phys_units
 
 
-def conversion_factors(t_int, binwidth_nm, calibration="new"):
+def get_conversion_factors(t_int, binwidth_nm, calibration="new"):
     """
     Identify and return the appropriate conversion factors for the data.
     """

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -951,8 +951,8 @@ def convert_l1a_to_l1c(light_fits, dark_fits, light_l1a_path, savepath, solv="Po
     # note that the actual backgroudn will be different from what IDL spits out because the
     # process of cleaning the data of rays and hot pixels produces ever so slightly different results, 
     # but it's done this way because the background is constructed after cleanup in the IDL pipeline.
-    back_below = np.sum(data[:, bg_inds[0]:bg_inds[1], :], axis=1) / (bg_inds[1] - bg_inds[0] + 1)
-    back_above = np.sum(data[:, bg_inds[2]:bg_inds[3], :], axis=1) / (bg_inds[3] - bg_inds[2] + 1)
+    back_below = np.sum(data[:, bg_inds[0]:bg_inds[1]+1, :], axis=1) / (bg_inds[1] - bg_inds[0] + 1)
+    back_above = np.sum(data[:, bg_inds[2]:bg_inds[3]+1, :], axis=1) / (bg_inds[3] - bg_inds[2] + 1)
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     # Arrays to store brightness values 

--- a/maven_iuvs/echelle.py
+++ b/maven_iuvs/echelle.py
@@ -747,7 +747,7 @@ def get_lya_countrates(idx_entry):
 # Metadata -------------------------------------------------------------
 
 
-def get_dir_metadata(the_dir, new_files_limit=None):
+def get_dir_metadata(the_dir, geospatial=False, new_files_limit=None):
     """
     Collect the metadata for all files within the_dir. May contain
     subdirectories.
@@ -765,7 +765,11 @@ def get_dir_metadata(the_dir, new_files_limit=None):
     new_idx : list of dictionaries
               Each dictionary contains metadata for one file.
     """
-    idx_fname = the_dir[:-1] + '_metadata.npy'
+    if geospatial:
+        name_ext = "_metadata_geosp.npy"
+    else:
+        name_ext = "_metadata.npy"
+    idx_fname = the_dir[:-1] +  name_ext
     print(f'loading {idx_fname}...')
     
     try:
@@ -794,7 +798,8 @@ def get_dir_metadata(the_dir, new_files_limit=None):
             
             f_metadata = get_file_metadata(find_files(data_directory=the_dir,
                                                       use_index=False,
-                                                      pattern=f)[0])
+                                                      pattern=f)[0],
+                                           geospatial=geospatial)
             add_to_idx.append(f_metadata)
         
         print('\n... done')
@@ -884,7 +889,7 @@ def get_file_metadata(fname, geospatial=False):
     return metadata_dict
 
 
-def update_index(rootpath, new_files_limit_per_run=1000):
+def update_index(rootpath, geospatial=False, new_files_limit_per_run=1000):
     """
     Updates the index file for rootpath, where the index file has the form <rootpath>_metadata.npy.
     

--- a/maven_iuvs/graphics/echelle_graphics.py
+++ b/maven_iuvs/graphics/echelle_graphics.py
@@ -596,6 +596,8 @@ def make_one_quicklook(index_data_pair, light_path, dark_path, no_geo=None, show
     return "Success" 
 
 
+# LINE FITTING ========================================================
+
 def plot_line_fit(data_wavelengths, data_vals, model_fit, fit_params_for_printing, data_unc=None, H_a=0, H_b=0, D_a=0, D_b=0, t="Fit", unit="DN", show_integration_regions=False, logview=False, plot_bg=None):
     """
     Plots the fit defined by data_vals to the data, data_wavelengths and data_vals.
@@ -808,3 +810,36 @@ def plot_line_fit_comparison(data_wavelengths, data_vals_new, data_vals_BU, mode
     plt.show()
 
     pass
+
+
+def plot_background_in_no_spectrum_region(wavelengths, empty_spec_minus_bg, spec_lbl="", plottitle=""):
+    """
+    Simply plot a zero line and a supplied "spectrum" which we want to be close
+    to zero. In regions of the detector where no data are taken (off-slit), or in
+    dark frames, a "spectrum" in that region minus the background fit in that region
+    should be reasonably close to zero.
+    
+    Parameters
+    ----------
+    wavelengths : array
+                  Wavelengths in nm.
+    empty_spec_minus_bg : array
+                          The difference of: a "spectrum" from a region on the detector above the slit,
+                          and the background fitted in that region.
+                          Thus, this array should be relatively close to zero.
+    spec_lbl : string 
+               Legend label for the fake "spectrum" describing where it was obtained
+    plottitle : string
+                Title for overall plot
+    Returns
+    ----------
+    A plot.
+    """
+    rms_above = np.std(empty_spec_minus_bg)
+    fig, ax = plt.subplots()
+    ax.plot(wavelengths, empty_spec_minus_bg, color="xkcd:gray", label=spec_lbl)
+    ax.plot(wavelengths, np.zeros_like(empty_spec_minus_bg), color="xkcd:electric blue", linewidth=2, label="Zero line")
+    ax.set_ylim(-1, 1)
+    ax.text(0.05, 0.05, f"RMS = {np.round(rms_above, 2)}", transform=ax.transAxes)
+    ax.set_title(plottitle)
+    plt.show()

--- a/maven_iuvs/graphics/echelle_graphics.py
+++ b/maven_iuvs/graphics/echelle_graphics.py
@@ -602,6 +602,32 @@ def make_one_quicklook(index_data_pair, light_path, dark_path, no_geo=None, show
 
 # LINE FITTING ========================================================
 
+def example_fit_plot(data_wavelengths, data_vals, data_unc, model_fit):
+    mpl.rcParams["font.sans-serif"] = "Louis George Caf?"
+    mpl.rcParams['font.size'] = 18
+    mpl.rcParams['legend.fontsize'] = 16
+    mpl.rcParams['xtick.labelsize'] = 16
+    mpl.rcParams['ytick.labelsize'] = 16
+    mpl.rcParams['axes.labelsize'] = 18
+    mpl.rcParams['axes.titlesize'] = 22
+
+    model_color = "#1b9e77"
+    data_color = "#d95f02"
+    bg_color = "xkcd:cerulean"
+
+    fig, ax = plt.subplots(figsize=(5,3))
+        
+    # Plot the data and fit and a guideline for the central wavelength
+    ax.errorbar(data_wavelengths, data_vals, yerr=data_unc, color=data_color, linewidth=0,elinewidth=1, zorder=3)
+    ax.step(data_wavelengths, data_vals, where="mid", color=data_color, label="data", zorder=3, alpha=0.7)
+    ax.step(data_wavelengths, model_fit, where="mid", color=model_color, label="model fit", linewidth=2, zorder=2)
+
+    ax.set_ylabel("Brightness (kR/nm)")
+    ax.legend()
+    
+    ax.set_xlim(121.5, 121.65)#(min(data_wavelengths)-0.02, max(data_wavelengths)+0.02)# 
+    
+
 def plot_line_fit(data_wavelengths, data_vals, model_fit, fit_params_for_printing, wavelength_bin_edges=None, data_unc=None, 
                   t="Fit", fittext_x=[0.6, 0.6], fittext_y=[0.5, 0.4], 
                   logview=False, plot_bg=None, plot_subtract_bg=True, plot_bg_separately=False,
@@ -776,6 +802,10 @@ def plot_line_fit_comparison(data_wavelengths, data_vals_new, data_vals_BU, mode
     mpl.rcParams['axes.labelsize'] = 18
     mpl.rcParams['axes.titlesize'] = 22
 
+    model_color = "#1b9e77"
+    data_color = "#d95f02"
+    bg_color = "xkcd:cerulean"
+
     fig = plt.figure(figsize=(16,6))
     mygrid = gs.GridSpec(4, 2, figure=fig, hspace=0.1, wspace=0.1)
     mainax_new = plt.subplot(mygrid.new_subplotspec((0, 0), colspan=1, rowspan=3)) 
@@ -802,33 +832,31 @@ def plot_line_fit_comparison(data_wavelengths, data_vals_new, data_vals_BU, mode
             plot_model_new = model_fit_new - pybackground
             plot_data_BU = data_vals_BU - BUbackground
             plot_model_BU = model_fit_BU - BUbackground
-            mainax_new.plot(data_wavelengths, pybackground-50, label="background (offset=-50)", linewidth=2, zorder=2)
-            mainax_BU.plot(data_wavelengths, BUbackground-1, label="background  (offset=-1)", linewidth=2, zorder=2)
+            mainax_new.plot(data_wavelengths, pybackground-50, label="background (offset=-50)", linewidth=2, zorder=2, color=bg_color)
+            mainax_BU.plot(data_wavelengths, BUbackground-1, label="background  (offset=-1)", linewidth=2, zorder=2, color=bg_color)
         else: # show arrays with bg included, plot bg
             plot_data_new = data_vals_new 
             plot_model_new = model_fit_new
             plot_data_BU = data_vals_BU
             plot_model_BU = model_fit_BU
-            mainax_new.plot(data_wavelengths, pybackground, label="background", linewidth=2, zorder=2)
-            mainax_BU.plot(data_wavelengths, BUbackground, label="background", linewidth=2, zorder=2)
+            mainax_new.plot(data_wavelengths, pybackground, label="background", linewidth=2, zorder=2, color=bg_color)
+            mainax_BU.plot(data_wavelengths, BUbackground, label="background", linewidth=2, zorder=2, color=bg_color)
         
     # Plot the data and fit and a guideline for the central wavelength
-    mainax_new.errorbar(data_wavelengths, plot_data_new, yerr=data_unc_new, label="data", linewidth=1, zorder=3, alpha=0.7)
-    mainax_new.plot(data_wavelengths, plot_model_new, label="model", linewidth=2, zorder=2)
-    mainax_new.axvline(fit_params_new['lambdac'], color="gray", zorder=1, linewidth=0.5, )
+    mainax_new.errorbar(data_wavelengths, plot_data_new, yerr=data_unc_new, linewidth=0, zorder=3, alpha=0.7, color=data_color)
+    mainax_new.step(data_wavelengths, plot_data_new, where="mid", label="data", linewidth=1, zorder=3, alpha=0.7, color=data_color)
+    mainax_new.step(data_wavelengths, plot_model_new, where="mid", label="model", linewidth=2, zorder=2, color=model_color)
 
-    mainax_BU.errorbar(data_wavelengths, plot_data_BU, yerr=data_unc_BU, label="data", linewidth=1, zorder=3, alpha=0.7)
-    mainax_BU.plot(data_wavelengths, plot_model_BU, label="model", linewidth=2, zorder=2)
-    mainax_BU.axvline(fit_params_BU['lambdac'], color="gray", zorder=1, linewidth=0.5, )
+    mainax_BU.errorbar(data_wavelengths, plot_data_BU, yerr=data_unc_BU, linewidth=0, zorder=3, alpha=0.7, color=data_color)
+    mainax_BU.step(data_wavelengths, plot_data_BU, where="mid", label="data", linewidth=1, zorder=3, alpha=0.7, color=data_color)
+    mainax_BU.step(data_wavelengths, plot_model_BU, where="mid", label="model", linewidth=2, zorder=2, color=model_color)
 
-    # get index of lambda for D so we can find the value there
-    if fit_params_new["lambdac_D"] is not np.nan:
-        D_i = find_nearest(data_wavelengths, fit_params_new['lambdac_D'])[0]
-        mainax_new.axvline(fit_params_new['lambdac_D'], color="gray", linewidth=0.5, zorder=1)
-
-    if fit_params_BU["lambdac_D"] is not np.nan:
-        D_i = find_nearest(data_wavelengths, fit_params_BU['lambdac_D'])[0]
-        mainax_BU.axvline(fit_params_BU['lambdac_D'], color="gray", linewidth=0.5, zorder=1)
+    #  Plot the fit line centers on both residual and main axes
+    guideline_color = "xkcd:cool gray"
+    mainax_new.axvline(fit_params_new['lambdac'], color=guideline_color, zorder=1, lw=1)
+    mainax_BU.axvline(fit_params_BU['lambdac'], color=guideline_color, zorder=1, lw=1)
+    residax_new.axvline(fit_params_new['lambdac'], color=guideline_color, zorder=1, lw=1)
+    residax_BU.axvline(fit_params_BU['lambdac'], color=guideline_color, zorder=1, lw=1)
     
     # Print text
     printme_new = []
@@ -846,10 +874,10 @@ def plot_line_fit_comparison(data_wavelengths, data_vals_new, data_vals_BU, mode
     # printme_BU.append(f"H: {fit_params_BU['peakH']}\n± {round(fit_params_BU['uncert_H'], 2)} kR")
     # printme_BU.append(f"D: {fit_params_BU['peakD']}\n± {round(fit_params_BU['uncert_D'], 2)} kR")
 
-    printme_BU.append(f"H: {fit_params_BU['peakH']} ± {round(fit_params_BU['uncert_H'], 2)} "+
-                       f"kR (SNR: {round(fit_params_BU['peakH'] / fit_params_BU['uncert_H'], 1)})")
-    printme_BU.append(f"D: {fit_params_BU['peakD']} ± {round(fit_params_BU['uncert_D'], 2)} "+
-                       f"kR (SNR: {round(fit_params_BU['peakD'] / fit_params_BU['uncert_D'], 1)})")
+    printme_BU.append(f"H: {fit_params_BU['area']} ± {round(fit_params_BU['uncert_H'], 2)} "+
+                       f"kR (SNR: {round(fit_params_BU['area'] / fit_params_BU['uncert_H'], 1)})")
+    printme_BU.append(f"D: {fit_params_BU['area_D']} ± {round(fit_params_BU['uncert_D'], 2)} "+
+                       f"kR (SNR: {round(fit_params_BU['area_D'] / fit_params_BU['uncert_D'], 1)})")
 
     textx = [0.45, 0.45]#[0.38, 0.28]
     texty = [0.5, 0.4]#[0.5, 0.2]
@@ -868,18 +896,21 @@ def plot_line_fit_comparison(data_wavelengths, data_vals_new, data_vals_BU, mode
     mainax_BU.legend()
 
     # Residual axis
-    sign_new = np.sign(data_vals_new - model_fit_new)
-    residual_new = sign_new * np.abs(data_vals_new - model_fit_new)
-    residax_new.plot(data_wavelengths, residual_new, linewidth=1, color="xkcd:medium gray")
+    residual_color = "xkcd:dark lilac"
+    residual_new = (data_vals_new - model_fit_new)
+    residax_new.step(data_wavelengths, residual_new, where="mid", linewidth=1, color=residual_color)
+    residax_new.errorbar(data_wavelengths, residual_new, yerr=data_unc_new, color=residual_color, linewidth=0, elinewidth=1, zorder=3)
     bound = np.max([abs(np.min(residual_new)), np.max(residual_new)]) * 1.10
     residax_new.set_ylim(-bound, bound)
+    residax_new.axhline(0, color="xkcd:charcoal gray", linewidth=1, zorder=2)
 
-    sign_BU = np.sign(data_vals_BU - model_fit_BU)
-    residual_BU = sign_BU * np.abs(data_vals_BU - model_fit_BU)
+    residual_BU = (data_vals_BU - model_fit_BU)
     bound = np.max([abs(np.min(residual_BU)), np.max(residual_BU)])
     bound = bound * 1.10
-    residax_BU.plot(data_wavelengths, residual_BU, linewidth=1, color="xkcd:medium gray")
+    residax_BU.step(data_wavelengths, residual_BU, where="mid", linewidth=1, color="xkcd:medium gray")
+    residax_BU.errorbar(data_wavelengths, residual_BU, yerr=data_unc_BU, color=residual_color, linewidth=0, elinewidth=1, zorder=3)
     residax_BU.set_ylim(-bound, bound)
+    residax_BU.axhline(0, color="xkcd:charcoal gray", linewidth=1, zorder=2)
     plt.show()
 
     pass

--- a/maven_iuvs/graphics/echelle_graphics.py
+++ b/maven_iuvs/graphics/echelle_graphics.py
@@ -14,7 +14,7 @@ from maven_iuvs.binning import get_pix_range
 from maven_iuvs.instrument import ech_Lya_slit_start, ech_Lya_slit_end
 from maven_iuvs.echelle import make_dark_index, downselect_data, \
     pair_lights_and_darks, coadd_lights, find_files_missing_geometry, get_dark_frames, \
-    median_light_frame
+    subtract_darks
 from maven_iuvs.graphics import color_dict, make_sza_plot, make_tangent_lat_lon_plot, make_SCalt_plot
 from maven_iuvs.graphics.line_fit_plot import detector_image_echelle
 from maven_iuvs.miscellaneous import find_nearest, iuvs_orbno_from_fname, \
@@ -249,7 +249,7 @@ def quicklook_figure_skeleton(N_thumbs, figsz=(40, 24), thumb_cols=10, aspect=1)
 
 
 def make_one_quicklook(index_data_pair, light_path, dark_path, no_geo=None, show=True, savefolder=None, figsz=(36, 26), show_D_inset=True, show_D_guideline=True, 
-                       arange=None, prange=None, special_prange=[0, 65], show_DN_histogram=False, verbose=False, img_dpi=96, overwrite=False, fs="large", useframe="median"):
+                       arange=None, prange=None, special_prange=[0, 65], show_DN_histogram=False, verbose=False, img_dpi=96, overwrite=False, fs="large", useframe="coadded"):
     """ 
     Fills in the quicklook figure for a single observation.
     
@@ -329,10 +329,13 @@ def make_one_quicklook(index_data_pair, light_path, dark_path, no_geo=None, show
     n_ints_dark = get_n_int(dark_fits)
 
     # PROCESS THE DATA ---------------------------------------------------------------------------------
-    try: 
-        coadded_lights, n_frames, bad_inds = coadd_lights(light_fits, dark_fits)
-    except Exception as e:
-        return e
+
+    # Dark subtraction
+    dark_subtracted, n_good_frames, bad_inds =  subtract_darks(light_fits, dark_fits)
+
+    # determine plottable image
+    coadded_lights = coadd_lights(dark_subtracted, n_good_frames)
+    detector_image_to_plot = np.nanmedian(dark_subtracted, axis=0) if useframe=="median" else coadded_lights
 
     nan_light_inds, bad_light_inds, light_frames_with_nan_dark, nan_dark_inds = bad_inds  # unpack indices of problematic frames
 
@@ -536,15 +539,15 @@ def make_one_quicklook(index_data_pair, light_path, dark_path, no_geo=None, show
         if i in nan_light_inds:
             ThumbAxes[i].text(0.1, 1.1, "Missing data", color=color_dict['darkgrey'], va="top", fontsize=8+fontsizes[fs], transform=ThumbAxes[i].transAxes)
         elif i in bad_light_inds:
-            ThumbAxes[i].text(0.1, 1.1, "Saturated/broken", color=color_dict['darkgrey'], va="top", fontsize=14, transform=ThumbAxes[i].transAxes)
+            ThumbAxes[i].text(0.1, 1.1, "Saturated/broken", color=color_dict['darkgrey'], va="top", fontsize=8+fontsizes[fs], transform=ThumbAxes[i].transAxes)
         elif i in light_frames_with_nan_dark:
-            ThumbAxes[i].text(0.1, 1.1, "Bad dark frame", color=color_dict['darkgrey'], va="top", fontsize=14, transform=ThumbAxes[i].transAxes)
+            ThumbAxes[i].text(0.1, 1.1, "Bad dark frame", color=color_dict['darkgrey'], va="top", fontsize=8+fontsizes[fs], transform=ThumbAxes[i].transAxes)
 
         this_frame = light_fits['Primary'].data[i]
         detector_image_echelle(light_fits, this_frame, light_spapixrng, light_spepixrng, fig=QLfig, ax=ThumbAxes[i], scale="sqrt",
                                print_scale_type=False, show_colorbar=False, arange=arange, plot_full_extent=False,)
         
-    ThumbAxes[0].text(0, 1.3, f"{n_frames} total light frames co-added (pre-dark subtraction frames shown below):", fontsize=22, transform=ThumbAxes[0].transAxes)
+    ThumbAxes[0].text(0, 1.3, f"{n_good_frames} total light frames co-added (pre-dark subtraction frames shown below):", fontsize=22, transform=ThumbAxes[0].transAxes)
 
     # Explanatory text printing ----------------------------------------------------------------------------------
     utc_obj = iuvs_filename_to_datetime(light_fits['Primary'].header['filename'])
@@ -556,9 +559,9 @@ def make_one_quicklook(index_data_pair, light_path, dark_path, no_geo=None, show
     print_me = [f"Orbit {iuvs_orbno_from_fname(light_fits['Primary'].header['filename'])}:  {segment}",
                 f"Mars date: MY {My}, Sol {round(sol, 1)}, Ls {int(round(light_fits['Observation'].data['SOLAR_LONGITUDE'][0], ndigits=0))}°", 
                 f"UTC date/time: {utc_obj.strftime('%Y-%m-%d')}, {utc_obj.strftime('%H:%M:%S')}", 
-                f"{t1:<24}Light: {n_frames:<14}Dark: {n_ints_dark}",
+                f"{t1:<24}Light: {n_good_frames:<14}Dark: {n_ints_dark}",
                 f"{t2:<22}Light: {index_data_pair[0]['int_time']} s{'':<6}Dark: {index_data_pair[1]['int_time']} s",
-                f"Total light integrations: {(index_data_pair[0]['int_time'] * n_frames)} s",
+                f"Total light integrations: {(index_data_pair[0]['int_time'] * n_good_frames)} s",
                 #
                 f"Light file: {light_fits['Primary'].header['filename']}", 
                 f"Dark file: {dark_fits['Primary'].header['filename']}"]

--- a/maven_iuvs/instrument.py
+++ b/maven_iuvs/instrument.py
@@ -2,9 +2,7 @@ import os
 import numpy as np
 import math
 import pkg_resources
-from maven_iuvs.binning import get_pix_range
-from maven_iuvs.miscellaneous import iuvs_data_product_level_from_fname, get_n_int, \
-                                     find_nearest
+from maven_iuvs.miscellaneous import iuvs_data_product_level_from_fname
 
 # instrument variables
 slit_width_deg = 10  # [deg]

--- a/maven_iuvs/instrument.py
+++ b/maven_iuvs/instrument.py
@@ -283,7 +283,7 @@ def DN_to_PE_conversion_factor(light_fits):
     """
     gain = light_fits['Engineering'].data['MCP_GAIN'][0] # MCP gain in DN
     gain_v = mcp_dn_to_volt(gain)  # gives Gain in Volts
-    gain_PE  = mcp_volt_to_gain(gain_v, channel="FUV")  # gives Gain in PhotoElectrons    
+    gain_PE  = mcp_volt_to_gain(gain_v, channel=light_fits["Engineering"].data["XUV"])  # gives Gain in PhotoElectrons    
     conv_factor = 1 / (gain_PE)
 
     return conv_factor

--- a/maven_iuvs/instrument.py
+++ b/maven_iuvs/instrument.py
@@ -326,3 +326,22 @@ def ran_DN_uncertainty(light_fits, dark_subtracted_and_cleaned_data):
     ran_DN[np.where(np.isnan(ran_DN))] = 0 # TODO: this is not acceptable lol
 
     return ran_DN
+
+
+def get_wavelengths(light_fits):
+    """
+    Retrieves wavelengths for use from a given light file. This is done in more than one place,
+    so it was useful to make a dedicated function.
+
+    Parameters:
+    -----------
+    light_fits : astropy.io.fits instance
+                 File with light observation
+
+    Returns:
+    -----------
+    wavelength array as defined in the light_fits file.
+    """
+
+    # TODO: build in code that will account for the possible case where wavelengths shift per integration
+    return light_fits["Observation"].data["Wavelength"][0, 1, :]

--- a/maven_iuvs/instrument.py
+++ b/maven_iuvs/instrument.py
@@ -247,9 +247,9 @@ def mcp_volt_to_gain(volt, channel="FUV"):
 
 
 # TODO: Move these to appropriate places once done.
-def convert_spectrum_DN_to_photons(light_fits, spectrum):
+def convert_spectrum_DN_to_photoevents(light_fits, spectrum):
     """
-    Converts a spectrum in DN to photo events. 
+    Converts a spectrum in DN to photoevents, but doesn't fully calibrate it.
 
     Parameters
     ----------

--- a/maven_iuvs/instrument.py
+++ b/maven_iuvs/instrument.py
@@ -289,26 +289,6 @@ def DN_to_PE_conversion_factor(light_fits):
     return conv_factor
 
 
-def get_ech_slit_indices(light_fits):
-    """
-    Get the indices along the spatial dimension of the detector array that correspond 
-    to the beginning and end of the echelle slit. 
-
-    Parameters 
-    ----------
-    light_fits : astropy.io.fits instance
-                 File with light observation
-
-    Returns 
-    ----------
-    list containing slit_i1, slit_i2, the indices of the start and end of the slit. 
-    """
-    spapixrng = get_pix_range(light_fits, which="spatial")
-    slit_i1 = find_nearest(spapixrng, ech_Lya_slit_start)[0]  # start of slit
-    slit_i2 = find_nearest(spapixrng, ech_Lya_slit_end)[0]  # end of slit
-    return [slit_i1, slit_i2]
-
-
 def ran_DN_uncertainty(light_fits, dark_subtracted_and_cleaned_data):
     """
     Figure out the random uncertainty in DN.

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,8 @@ setuptools.setup(
         'mayavi>=4.7.2',
         'PyQt5>=5.15.2',
         'h5py>=2.10.0',
-        'idl_colorbars>=1.1.2'
+        'idl_colorbars>=1.1.2',
+        'scipy>=1.11.2',
+        'scikit-image>=0.21.0'
     ]
 )


### PR DESCRIPTION
## Pull Request Checklist
 - [x] Code Follows PEP8 guidelines (explain any exceptions)
 - [x] New routines don't duplicate existing functionality
 - [x] Original authors of modified routines have been added as reviewers

Note: There are some duplicate routines at present for the purposes of performing fits with two different backgrounds, one of which is prescribed (as it is done in the IDL pipeline):
- fit_line_BUbg
- badness_of_fit_BUbg
- lineshape_model_BUbg

Although this is ugly, this was simpler and cleaner than significantly modifying the existing routines with code that we may revert in the future once a path forward is decided on for the background subtraction. 

Discussion and improvements are needed in the following areas:

- **Hot pixel/cosmic ray cleanup:** The original IDL pipeline uses a nested-for loop approach. New functionality was built for this Python pipeline that performs a similar operation using vectorization and sliding window views. However, this introduces some differences in calculations. The IDL pipeline includes various calls to MEDIAN(), without the /EVEN keyword. This means that in some cases, the IDL pipeline encounters an array with an even number of entries, and upon running MEDIAN() on it, returns the equivalent of Python's statistics.median_high(). E.g., [1, 2, 4, 6] would return a median value of 4 in the IDL pipeline but 3 in Python. It does not seem possible to easily vectorize statistics.median_high() to match the IDL pipeline routine, so we should decide which median behavior is preferred. See the following image for a comparison of how the cleanup routines affect the spectrum; note that these variations work out to a small (~0.05 kR) variation in the brightness of the final fit, not very significant.

![ex_spectrums_after_cleanup](https://github.com/lasp/maven_iuvs/assets/4439854/b18f03b4-31ee-46b4-a99f-e38267ce357e)

- **Uncertainties**: A skeleton of the uncertainty estimation is included based on work by Matteo Crismani. It's probably not done correctly and needs to be modified with error from the fitting routine.
- **Brightnesses**: The retrieved brightnesses are still not matching the results from the IDL pipeline very well, at least not for D. Attempts to include the IDL background subtraction did not solve the issue, nor did ensuring the cleaned spectra are as close as possible to the cleaned spectra produced by IDL. There is likely an unknown error affecting this. Places to look include binning/pixel/wavelength conversions, or the effective aperture factor (A_eff).
